### PR TITLE
Security fixes, logic bug fixes, and role-based access control

### DIFF
--- a/ToDoTimeManager.DataBase/StoredProcedures/Users/sp_Users_Update.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Users/sp_Users_Update.sql
@@ -1,9 +1,9 @@
 ﻿CREATE PROCEDURE [dbo].[sp_Users_Update]
-	@Id UniqueIdentifier,
+	@Id UNIQUEIDENTIFIER,
 	@UserName NVARCHAR(256),
 	@Email NVARCHAR(256),
 	@Password NVARCHAR(512),
-	@UserRole BIT
+	@UserRole INT
 AS
 	BEGIN
 		UPDATE dbo.Users

--- a/ToDoTimeManager.Shared/DTOs/ChangeUserRoleRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/ChangeUserRoleRequestDto.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Enums;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class ChangeUserRoleRequestDto
+{
+    [Required]
+    public UserRole NewRole { get; set; }
+}

--- a/ToDoTimeManager.Shared/DTOs/UpdateUserRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/UpdateUserRequestDto.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Utils;
 
 namespace ToDoTimeManager.Shared.DTOs;
@@ -19,10 +18,6 @@ public sealed class UpdateUserRequestDto
     [MaxLength(200)]
     public string Email { get; set; } = string.Empty;
 
-    [Required]
-    public UserRole? UserRole { get; set; }
-
-    // Optional in case we later support "change password" from UI.
     [MinLength(6)]
     [MaxLength(200)]
     public string? Password { get; set; }

--- a/ToDoTimeManager.WebApi/Controllers/StatisticController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/StatisticController.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
@@ -12,17 +13,23 @@ namespace ToDoTimeManager.WebApi.Controllers
     {
         private readonly ILogger<StatisticController> _logger;
         private readonly IStatisticService _statisticService;
+
         public StatisticController(ILogger<StatisticController> logger, IStatisticService statisticService)
         {
             _logger = logger;
             _statisticService = statisticService;
         }
 
+        private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        private bool IsAdmin() => User.IsInRole("Admin");
+
         [HttpGet("GetToDoCountStatisticsOfAllTimeByUserId/{userId}")]
         public async Task<IActionResult> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId)
         {
             if (userId == Guid.Empty)
                 return BadRequest("Invalid user ID");
+            if (userId != GetCurrentUserId() && !IsAdmin())
+                return Forbid();
             var statistics = await _statisticService.GetToDoCountStatisticsOfAllTimeByUserId(userId);
             return Ok(statistics);
         }
@@ -32,6 +39,8 @@ namespace ToDoTimeManager.WebApi.Controllers
         {
             if (filter.UserId == Guid.Empty)
                 return BadRequest("Invalid user ID");
+            if (filter.UserId != GetCurrentUserId() && !IsAdmin())
+                return Forbid();
             var statistic = await _statisticService.GetMainPageStatistic(filter);
             return Ok(statistic);
         }

--- a/ToDoTimeManager.WebApi/Controllers/TimeLogsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/TimeLogsController.cs
@@ -1,7 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using ToDoTimeManager.Shared.Models;
+using System.Security.Claims;
 using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
@@ -20,6 +21,10 @@ public class TimeLogsController : ControllerBase
         _timeLogsService = timeLogsService;
     }
 
+    private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+    private bool IsAdmin() => User.IsInRole("Admin");
+
+    [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
     public async Task<IActionResult> GetAllTimeLogs()
     {
@@ -33,7 +38,10 @@ public class TimeLogsController : ControllerBase
         if (id == Guid.Empty)
             return BadRequest("Invalid time log ID");
         var timeLog = await _timeLogsService.GetTimeLogById(id);
-        return timeLog == null ? NotFound("Time log was not found") : Ok(timeLog);
+        if (timeLog == null) return NotFound("Time log was not found");
+        if (timeLog.UserId != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
+        return Ok(timeLog);
     }
 
     [HttpGet("GetByToDoId/{toDoId}")]
@@ -50,6 +58,8 @@ public class TimeLogsController : ControllerBase
     {
         if (userId == Guid.Empty)
             return BadRequest("Invalid user ID");
+        if (userId != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
         var timeLogs = await _timeLogsService.GetTimeLogsByUserId(userId);
         return Ok(timeLogs);
     }
@@ -61,6 +71,8 @@ public class TimeLogsController : ControllerBase
             return BadRequest("Invalid user ID");
         if (toDoId == Guid.Empty)
             return BadRequest("Invalid to-do ID");
+        if (userId != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
         var timeLogs = await _timeLogsService.GetTimeLogsByUserIdAndToDoId(toDoId, userId);
         return Ok(timeLogs);
     }
@@ -85,6 +97,11 @@ public class TimeLogsController : ControllerBase
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateTimeLog([FromBody] TimeLogUpsertRequestDto request)
     {
+        var existing = await _timeLogsService.GetTimeLogById(request.Id);
+        if (existing == null) return NotFound("Time log was not found");
+        if (existing.UserId != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
+
         var timeLog = new TimeLog
         {
             Id = request.Id,
@@ -104,6 +121,10 @@ public class TimeLogsController : ControllerBase
     {
         if (id == Guid.Empty)
             return BadRequest("Invalid time log ID");
+        var existing = await _timeLogsService.GetTimeLogById(id);
+        if (existing == null) return NotFound("Time log was not found");
+        if (existing.UserId != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
         var deleted = await _timeLogsService.DeleteTimeLog(id);
         return deleted ? Ok(deleted) : BadRequest("Time log could not be deleted");
     }

--- a/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using ToDoTimeManager.Shared.DTOs;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Services.Interfaces;
@@ -20,6 +21,10 @@ public class ToDosController : ControllerBase
         _toDosService = toDosService;
     }
 
+    private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+    private bool IsAdmin() => User.IsInRole("Admin");
+
+    [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
     public async Task<IActionResult> GetAllToDos()
     {
@@ -33,7 +38,10 @@ public class ToDosController : ControllerBase
         if (id == Guid.Empty)
             return BadRequest("Invalid to-do ID");
         var toDo = await _toDosService.GetToDoById(id);
-        return toDo == null ? NotFound("To-do was not found") : Ok(toDo);
+        if (toDo == null) return NotFound("To-do was not found");
+        if (toDo.AssignedTo != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
+        return Ok(toDo);
     }
 
     [HttpGet("GetByUserId/{userId}")]
@@ -41,6 +49,8 @@ public class ToDosController : ControllerBase
     {
         if (userId == Guid.Empty)
             return BadRequest("Invalid user ID");
+        if (userId != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
         var toDos = await _toDosService.GetToDosByUserId(userId);
         return Ok(toDos);
     }
@@ -67,6 +77,11 @@ public class ToDosController : ControllerBase
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateToDo([FromBody] ToDoUpsertRequestDto request)
     {
+        var existing = await _toDosService.GetToDoById(request.Id);
+        if (existing == null) return NotFound("To-do was not found");
+        if (existing.AssignedTo != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
+
         var toDo = new ToDo
         {
             Id = request.Id,
@@ -88,6 +103,10 @@ public class ToDosController : ControllerBase
     {
         if (id == Guid.Empty)
             return BadRequest("Invalid to-do ID");
+        var existing = await _toDosService.GetToDoById(id);
+        if (existing == null) return NotFound("To-do was not found");
+        if (existing.AssignedTo != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
         var deletedToDo = await _toDosService.DeleteToDo(id);
         return deletedToDo ? Ok(deletedToDo) : BadRequest("To-do could not be deleted");
     }

--- a/ToDoTimeManager.WebApi/Controllers/UsersController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/UsersController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Linq;
+using System.Security.Claims;
 using ToDoTimeManager.Shared.DTOs;
 using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
@@ -24,7 +25,10 @@ public class UsersController : ControllerBase
         _passwordHelperService = passwordHelperService;
     }
 
-    [Authorize]
+    private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+    private bool IsAdmin() => User.IsInRole("Admin");
+
+    [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
     public async Task<IActionResult> GetAllUsers()
     {
@@ -38,11 +42,13 @@ public class UsersController : ControllerBase
     {
         if (id == Guid.Empty)
             return BadRequest("Invalid user ID");
+        if (id != GetCurrentUserId() && !IsAdmin())
+            return Forbid();
         var user = await _usersService.GetUserById(id);
         return user == null ? NotFound("User was not found") : Ok(ToUserResponseDto(user));
     }
 
-    [Authorize]
+    [Authorize(Roles = "Admin")]
     [HttpGet("GetByUsername/{userName}")]
     public async Task<IActionResult> GetUserByUsername(string userName)
     {
@@ -52,7 +58,7 @@ public class UsersController : ControllerBase
         return user is null ? NotFound("User was not found") : Ok(ToUserResponseDto(user));
     }
 
-    [Authorize]
+    [Authorize(Roles = "Admin")]
     [HttpGet("GetByEmail/{email}")]
     public async Task<IActionResult> GetUserByEmail(string email)
     {
@@ -62,7 +68,7 @@ public class UsersController : ControllerBase
         return user is null ? NotFound("User was not found") : Ok(ToUserResponseDto(user));
     }
 
-    [Authorize]
+    [Authorize(Roles = "Admin")]
     [HttpGet("GetByLoginParameter/{loginParameter}")]
     public async Task<IActionResult> GetUserByLoginParameter(string loginParameter)
     {
@@ -93,6 +99,9 @@ public class UsersController : ControllerBase
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateUser([FromBody] UpdateUserRequestDto request)
     {
+        if (request.Id != GetCurrentUserId())
+            return Forbid();
+
         var existingUser = await _usersService.GetUserById(request.Id);
         if (existingUser is null)
             return NotFound("User was not found");
@@ -109,7 +118,7 @@ public class UsersController : ControllerBase
             Id = request.Id,
             UserName = request.UserName,
             Email = request.Email,
-            UserRole = request.UserRole,
+            UserRole = existingUser.UserRole,  // role is never changed via this endpoint
             Password = passwordHash
         };
 
@@ -117,7 +126,17 @@ public class UsersController : ControllerBase
         return res ? Ok(res) : BadRequest("User could not be updated");
     }
 
-    [Authorize]
+    [Authorize(Roles = "Admin")]
+    [HttpPut("ChangeRole/{id}")]
+    public async Task<IActionResult> ChangeUserRole(Guid id, [FromBody] ChangeUserRoleRequestDto request)
+    {
+        if (id == Guid.Empty)
+            return BadRequest("Invalid user ID");
+        var changed = await _usersService.ChangeUserRole(id, request.NewRole);
+        return changed ? Ok(changed) : NotFound("User was not found");
+    }
+
+    [Authorize(Roles = "Admin")]
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteUser(Guid id)
     {

--- a/ToDoTimeManager.WebApi/Services/Implementations/UsersService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/UsersService.cs
@@ -1,4 +1,5 @@
-﻿using ToDoTimeManager.Shared.Models;
+﻿using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Entities;
 using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
@@ -109,6 +110,22 @@ public class UsersService : IUsersService
         try
         {
             return await _usersDataController.UpdateUser(new UserEntity(updatedUser));
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
+    }
+
+    public async Task<bool> ChangeUserRole(Guid userId, UserRole newRole)
+    {
+        try
+        {
+            var existing = await _usersDataController.GetUserById(userId);
+            if (existing is null) return false;
+            existing.UserRole = newRole;
+            return await _usersDataController.UpdateUser(existing);
         }
         catch (Exception e)
         {

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IUsersService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IUsersService.cs
@@ -1,4 +1,5 @@
-﻿using ToDoTimeManager.Shared.Models;
+﻿using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.WebApi.Services.Interfaces;
 
@@ -11,5 +12,6 @@ public interface IUsersService
     Task<User?> GetUserByLoginParameter(string loginParameter);
     Task<bool> CreateUser(User newUser);
     Task<bool> UpdateUser(User updatedUser);
+    Task<bool> ChangeUserRole(Guid userId, UserRole newRole);
     Task<bool> DeleteUser(Guid userId);
 }

--- a/ToDoTimeManager.WebUI/Components/Modals/UserEditModal.razor
+++ b/ToDoTimeManager.WebUI/Components/Modals/UserEditModal.razor
@@ -60,8 +60,7 @@
             {
                 Id = User.Id,
                 UserName = User.UserName ?? string.Empty,
-                Email = User.Email ?? string.Empty,
-                UserRole = User.UserRole
+                Email = User.Email ?? string.Empty
             };
         }
 


### PR DESCRIPTION
## Summary

### Commit 1 — Security vulnerabilities and logic bug fixes
- **UsersController**: force `UserRole=User` on registration (prevent Admin escalation via API)
- **AuthService**: replace unvalidated `ReadJwtToken` with server-side `ValidateToken` on refresh — forged tokens no longer accepted
- **StatisticService**: fix `DateTime.Now.Day` used as days-ago for "this month" — now computes actual days since UTC month start
- **GlobalExceptionHandler**: return HTTP 500 with generic message instead of HTTP 204 with `exception.Message` (info disclosure)
- **JwtGeneratorService**: `DateTime.Now` → `DateTime.UtcNow` for token expiry
- **AuthController.RefreshToken**: remove redundant `async`/pragma suppression
- **sp_Users_DeleteById**: remove duplicate UPDATE statement, fix `UNIQUEIDENTIFIER` casing
- **sp_ToDos_GetByNearestDueDateByUserId**: `GETDATE()` → `GETUTCDATE()`
- **ToastsService.Dispose**: add `Timer.Stop()/Timer.Dispose()` to prevent resource leak

### Commit 2 — Role-based access control (RBAC)
- **sp_Users_Update**: fix `@UserRole BIT` → `INT` (type mismatch with table column)
- **UpdateUserRequestDto**: remove `UserRole` field — users can no longer escalate their own role via profile update
- **ChangeUserRoleRequestDto**: new DTO for admin-only role change endpoint
- **IUsersService / UsersService**: new `ChangeUserRole` method
- **UsersController**: `GetAll`, `GetByUsername`, `GetByEmail`, `GetByLoginParameter`, `Delete` → `[Authorize(Roles="Admin")]`; new `PUT ChangeRole/{id}` admin endpoint; `GetById`/`Update` have ownership checks
- **ToDosController**: `GetAll` → `[Authorize(Roles="Admin")]`; `GetById`, `GetByUserId`, `Update`, `Delete` → ownership check
- **TimeLogsController**: `GetAll` → `[Authorize(Roles="Admin")]`; `GetById`, `GetByUserId`, `GetByUserIdAndToDoId`, `Update`, `Delete` → ownership check
- **StatisticController**: both endpoints → ownership check (`userId == currentUserId || IsAdmin`)
- **UserEditModal.razor**: remove `UserRole` assignment (field no longer in DTO)

## Test plan
- [ ] `GET /api/users/GetAll` as User → 403; as Admin → 200
- [ ] `PUT /api/users/ChangeRole/{id}` as User → 403; as Admin → 200
- [ ] `GET /api/todos/GetAll` as User → 403; as Admin → 200
- [ ] `GET /api/todos/GetByUserId/{foreignId}` as User → 403
- [ ] `PUT /api/users/Update` with another user's Id → 403
- [ ] Login, refresh token — both still work correctly
- [ ] Statistics endpoint with own userId → 200; with foreign userId as User → 403

https://claude.ai/code/session_012SPg2uvhnYgm9zgEtRMprW

---
_Generated by [Claude Code](https://claude.ai/code/session_012SPg2uvhnYgm9zgEtRMprW)_