### PR TITLE
feat: add Teams backend feature

### DIFF
--- a/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_Create.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_Create.sql
@@ -1,0 +1,11 @@
+CREATE PROCEDURE [dbo].[sp_TeamMembers_Create]
+    @Id     UNIQUEIDENTIFIER,
+    @TeamId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @Role   INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    INSERT INTO [dbo].[TeamMembers] (Id, TeamId, UserId, Role)
+    VALUES (@Id, @TeamId, @UserId, @Role);
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_DeleteByTeamIdAndUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_DeleteByTeamIdAndUserId.sql
@@ -1,0 +1,10 @@
+CREATE PROCEDURE [dbo].[sp_TeamMembers_DeleteByTeamIdAndUserId]
+    @TeamId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DELETE FROM [dbo].[TeamMembers]
+    WHERE TeamId = @TeamId
+      AND UserId = @UserId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_GetById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_GetById.sql
@@ -1,0 +1,9 @@
+CREATE PROCEDURE [dbo].[sp_TeamMembers_GetById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT Id, TeamId, UserId, Role
+    FROM [dbo].[TeamMembers]
+    WHERE Id = @Id;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_GetByTeamId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_GetByTeamId.sql
@@ -1,0 +1,9 @@
+CREATE PROCEDURE [dbo].[sp_TeamMembers_GetByTeamId]
+    @TeamId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT Id, TeamId, UserId, Role
+    FROM [dbo].[TeamMembers]
+    WHERE TeamId = @TeamId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_GetByTeamIdAndUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TeamMembers/sp_TeamMembers_GetByTeamIdAndUserId.sql
@@ -1,0 +1,11 @@
+CREATE PROCEDURE [dbo].[sp_TeamMembers_GetByTeamIdAndUserId]
+    @TeamId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT Id, TeamId, UserId, Role
+    FROM [dbo].[TeamMembers]
+    WHERE TeamId = @TeamId
+      AND UserId = @UserId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_Create.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_Create.sql
@@ -1,0 +1,12 @@
+CREATE PROCEDURE [dbo].[sp_Teams_Create]
+    @Id          UNIQUEIDENTIFIER,
+    @Name        NVARCHAR(100),
+    @Description NVARCHAR(500),
+    @CreatedAt   DATETIME,
+    @CreatedBy   UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    INSERT INTO [dbo].[Teams] (Id, Name, Description, CreatedAt, CreatedBy)
+    VALUES (@Id, @Name, @Description, @CreatedAt, @CreatedBy);
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_DeleteById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_DeleteById.sql
@@ -1,0 +1,16 @@
+CREATE PROCEDURE [dbo].[sp_Teams_DeleteById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE [dbo].[ToDos]
+    SET TeamId = NULL
+    WHERE TeamId = @Id;
+
+    DELETE FROM [dbo].[TeamMembers]
+    WHERE TeamId = @Id;
+
+    DELETE FROM [dbo].[Teams]
+    WHERE Id = @Id;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_GetAll.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_GetAll.sql
@@ -1,0 +1,16 @@
+CREATE PROCEDURE [dbo].[sp_Teams_GetAll]
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT
+        t.Id,
+        t.Name,
+        t.Description,
+        t.CreatedAt,
+        t.CreatedBy,
+        COUNT(tm.Id) AS MemberCount
+    FROM [dbo].[Teams] t
+    LEFT JOIN [dbo].[TeamMembers] tm ON tm.TeamId = t.Id
+    GROUP BY t.Id, t.Name, t.Description, t.CreatedAt, t.CreatedBy
+    ORDER BY t.Name ASC;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_GetById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_GetById.sql
@@ -1,0 +1,17 @@
+CREATE PROCEDURE [dbo].[sp_Teams_GetById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT
+        t.Id,
+        t.Name,
+        t.Description,
+        t.CreatedAt,
+        t.CreatedBy,
+        COUNT(tm.Id) AS MemberCount
+    FROM [dbo].[Teams] t
+    LEFT JOIN [dbo].[TeamMembers] tm ON tm.TeamId = t.Id
+    WHERE t.Id = @Id
+    GROUP BY t.Id, t.Name, t.Description, t.CreatedAt, t.CreatedBy;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_GetByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_GetByUserId.sql
@@ -1,0 +1,18 @@
+CREATE PROCEDURE [dbo].[sp_Teams_GetByUserId]
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT
+        t.Id,
+        t.Name,
+        t.Description,
+        t.CreatedAt,
+        t.CreatedBy,
+        COUNT(tm2.Id) AS MemberCount
+    FROM [dbo].[Teams] t
+    INNER JOIN [dbo].[TeamMembers] tm  ON tm.TeamId  = t.Id AND tm.UserId = @UserId
+    LEFT JOIN  [dbo].[TeamMembers] tm2 ON tm2.TeamId = t.Id
+    GROUP BY t.Id, t.Name, t.Description, t.CreatedAt, t.CreatedBy
+    ORDER BY t.Name ASC;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_Update.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_Update.sql
@@ -1,0 +1,12 @@
+CREATE PROCEDURE [dbo].[sp_Teams_Update]
+    @Id          UNIQUEIDENTIFIER,
+    @Name        NVARCHAR(100),
+    @Description NVARCHAR(500)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE [dbo].[Teams]
+    SET Name        = @Name,
+        Description = @Description
+    WHERE Id = @Id;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Create.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Create.sql
@@ -1,12 +1,13 @@
 ﻿CREATE PROCEDURE [dbo].[sp_ToDos_Create]
-	@Id UNIQUEIDENTIFIER,
-	@NumberedId INT,
-	@Title NVARCHAR(100),
+	@Id          UNIQUEIDENTIFIER,
+	@NumberedId  INT,
+	@Title       NVARCHAR(100),
 	@Description NVARCHAR(MAX),
-	@CreatedAt DATETIME,
-	@DueDate DATETIME,
-	@Status INT,
-	@AssignedTo UNIQUEIDENTIFIER
+	@CreatedAt   DATETIME,
+	@DueDate     DATETIME,
+	@Status      INT,
+	@AssignedTo  UNIQUEIDENTIFIER,
+	@TeamId      UNIQUEIDENTIFIER
 AS
 	INSERT INTO [dbo].[ToDos] (
 		Id,
@@ -16,7 +17,8 @@ AS
 		DueDate,
 		Status,
 		AssignedTo,
-		NumberedId
+		NumberedId,
+		TeamId
 	)
 	VALUES (
 		@Id,
@@ -26,5 +28,6 @@ AS
 		@DueDate,
 		@Status,
 		@AssignedTo,
-		(SELECT ISNULL(MAX(NumberedId), 0) + 1 FROM [dbo].[ToDos])
+		(SELECT ISNULL(MAX(NumberedId), 0) + 1 FROM [dbo].[ToDos]),
+		@TeamId
 	)

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetAll.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetAll.sql
@@ -1,5 +1,5 @@
 ﻿CREATE PROCEDURE [dbo].[sp_ToDos_GetAll]
-AS 
+AS
 	SELECT
 		Id,
 		Title,
@@ -8,6 +8,7 @@ AS
 		DueDate,
 		Status,
 		AssignedTo,
-		NumberedId
+		NumberedId,
+		TeamId
 	FROM
 		[dbo].[ToDos]

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByAssignedTo.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByAssignedTo.sql
@@ -9,7 +9,8 @@ AS
 		DueDate,
 		Status,
 		AssignedTo,
-		NumberedId
-		FROM [dbo].[ToDos]
-		WHERE AssignedTo = @AssignedTo
+		NumberedId,
+		TeamId
+	FROM [dbo].[ToDos]
+	WHERE AssignedTo = @AssignedTo
 

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetById.sql
@@ -1,7 +1,7 @@
 ﻿CREATE PROCEDURE [dbo].[sp_ToDos_GetById]
 	@Id UNIQUEIDENTIFIER
 AS
-	SELECT 
+	SELECT
 		Id,
 		Title,
 		Description,
@@ -9,6 +9,7 @@ AS
 		DueDate,
 		Status,
 		AssignedTo,
-		NumberedId
+		NumberedId,
+		TeamId
 	FROM [dbo].[ToDos]
 	WHERE Id = @Id

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByNearestDueDateByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByNearestDueDateByUserId.sql
@@ -4,8 +4,17 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
-    SELECT *
-    FROM ToDos
+    SELECT
+        Id,
+        Title,
+        Description,
+        CreatedAt,
+        DueDate,
+        Status,
+        AssignedTo,
+        NumberedId,
+        TeamId
+    FROM [dbo].[ToDos]
     WHERE AssignedTo = @UserId
       AND DueDate IS NOT NULL
       AND CAST(DueDate AS DATE) >= CAST(GETUTCDATE() AS DATE)

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByTeamId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByTeamId.sql
@@ -1,0 +1,18 @@
+CREATE PROCEDURE [dbo].[sp_ToDos_GetByTeamId]
+    @TeamId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT
+        Id,
+        Title,
+        Description,
+        CreatedAt,
+        DueDate,
+        Status,
+        AssignedTo,
+        NumberedId,
+        TeamId
+    FROM [dbo].[ToDos]
+    WHERE TeamId = @TeamId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Update.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Update.sql
@@ -1,20 +1,22 @@
 ﻿CREATE PROCEDURE [dbo].[sp_ToDos_Update]
-    @Id UNIQUEIDENTIFIER,
-    @Title NVARCHAR(100),
+    @Id          UNIQUEIDENTIFIER,
+    @Title       NVARCHAR(100),
     @Description NVARCHAR(MAX),
-    @CreatedAt DATETIME,
-    @DueDate DATETIME,
-    @Status INT,
-    @AssignedTo UNIQUEIDENTIFIER,
-    @NumberedId INT
+    @CreatedAt   DATETIME,
+    @DueDate     DATETIME,
+    @Status      INT,
+    @AssignedTo  UNIQUEIDENTIFIER,
+    @NumberedId  INT,
+    @TeamId      UNIQUEIDENTIFIER
 AS
     UPDATE [dbo].[ToDos]
     SET
-        Title = @Title,
+        Title       = @Title,
         Description = @Description,
-        CreatedAt = @CreatedAt,
-        DueDate = @DueDate,
-        Status = @Status,
-        AssignedTo = @AssignedTo
+        CreatedAt   = @CreatedAt,
+        DueDate     = @DueDate,
+        Status      = @Status,
+        AssignedTo  = @AssignedTo,
+        TeamId      = @TeamId
     WHERE
         Id = @Id

--- a/ToDoTimeManager.DataBase/Tables/TeamMembers.sql
+++ b/ToDoTimeManager.DataBase/Tables/TeamMembers.sql
@@ -1,0 +1,10 @@
+CREATE TABLE [dbo].[TeamMembers]
+(
+    Id     UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
+    TeamId UNIQUEIDENTIFIER NOT NULL,
+    UserId UNIQUEIDENTIFIER NOT NULL,
+    Role   INT              NOT NULL DEFAULT 0,
+    CONSTRAINT [FK_TeamMembers_Teams] FOREIGN KEY ([TeamId]) REFERENCES [Teams]([Id]),
+    CONSTRAINT [FK_TeamMembers_Users] FOREIGN KEY ([UserId]) REFERENCES [Users]([Id]),
+    CONSTRAINT [UQ_TeamMembers_TeamId_UserId] UNIQUE ([TeamId], [UserId])
+)

--- a/ToDoTimeManager.DataBase/Tables/Teams.sql
+++ b/ToDoTimeManager.DataBase/Tables/Teams.sql
@@ -1,0 +1,9 @@
+CREATE TABLE [dbo].[Teams]
+(
+    Id          UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
+    Name        NVARCHAR(100)    NOT NULL,
+    Description NVARCHAR(500)    NULL,
+    CreatedAt   DATETIME         NOT NULL,
+    CreatedBy   UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT [FK_Teams_Users_CreatedBy] FOREIGN KEY ([CreatedBy]) REFERENCES [Users]([Id])
+)

--- a/ToDoTimeManager.DataBase/Tables/ToDos.sql
+++ b/ToDoTimeManager.DataBase/Tables/ToDos.sql
@@ -7,6 +7,8 @@
     CreatedAt DATETIME NOT NULL,
     DueDate DATETIME NULL,
     Status INT NOT NULL,
-    AssignedTo UNIQUEIDENTIFIER NULL, 
-    CONSTRAINT [FK_ToDos_Users] FOREIGN KEY ([AssignedTo]) REFERENCES [Users]([Id])
+    AssignedTo UNIQUEIDENTIFIER NULL,
+    TeamId     UNIQUEIDENTIFIER NULL,
+    CONSTRAINT [FK_ToDos_Users]  FOREIGN KEY ([AssignedTo]) REFERENCES [Users]([Id]),
+    CONSTRAINT [FK_ToDos_Teams]  FOREIGN KEY ([TeamId])     REFERENCES [Teams]([Id])
 )

--- a/ToDoTimeManager.DataBase/ToDoTimeManager.DataBase.sqlproj
+++ b/ToDoTimeManager.DataBase/ToDoTimeManager.DataBase.sqlproj
@@ -61,11 +61,15 @@
     <Folder Include="StoredProcedures\TimeLogs" />
     <Folder Include="StoredProcedures\ToDos" />
     <Folder Include="StoredProcedures\Users" />
+    <Folder Include="StoredProcedures\Teams" />
+    <Folder Include="StoredProcedures\TeamMembers" />
   </ItemGroup>
   <ItemGroup>
+    <Build Include="Tables\Users.sql" />
+    <Build Include="Tables\Teams.sql" />
+    <Build Include="Tables\TeamMembers.sql" />
     <Build Include="Tables\TimeLogs.sql" />
     <Build Include="Tables\ToDos.sql" />
-    <Build Include="Tables\Users.sql" />
     <Build Include="StoredProcedures\Users\sp_Users_Create.sql" />
     <Build Include="StoredProcedures\Users\sp_Users_GetById.sql" />
     <Build Include="StoredProcedures\ToDos\sp_ToDos_Create.sql" />
@@ -91,5 +95,17 @@
     <Build Include="StoredProcedures\ToDos\sp_ToDos_GetCountByUserIdAndStatus.sql" />
     <Build Include="StoredProcedures\TimeLogs\sp_TimeLogs_GetByUserIdAndTime.sql" />
     <Build Include="StoredProcedures\ToDos\sp_ToDos_GetByNearestDueDateByUserId.sql" />
+    <Build Include="StoredProcedures\ToDos\sp_ToDos_GetByTeamId.sql" />
+    <Build Include="StoredProcedures\Teams\sp_Teams_Create.sql" />
+    <Build Include="StoredProcedures\Teams\sp_Teams_GetAll.sql" />
+    <Build Include="StoredProcedures\Teams\sp_Teams_GetById.sql" />
+    <Build Include="StoredProcedures\Teams\sp_Teams_Update.sql" />
+    <Build Include="StoredProcedures\Teams\sp_Teams_DeleteById.sql" />
+    <Build Include="StoredProcedures\Teams\sp_Teams_GetByUserId.sql" />
+    <Build Include="StoredProcedures\TeamMembers\sp_TeamMembers_Create.sql" />
+    <Build Include="StoredProcedures\TeamMembers\sp_TeamMembers_GetById.sql" />
+    <Build Include="StoredProcedures\TeamMembers\sp_TeamMembers_GetByTeamId.sql" />
+    <Build Include="StoredProcedures\TeamMembers\sp_TeamMembers_GetByTeamIdAndUserId.sql" />
+    <Build Include="StoredProcedures\TeamMembers\sp_TeamMembers_DeleteByTeamIdAndUserId.sql" />
   </ItemGroup>
 </Project>

--- a/ToDoTimeManager.Shared/DTOs/CreateTeamRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/CreateTeamRequestDto.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Utils;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class CreateTeamRequestDto
+{
+    [NotEmptyGuid]
+    public Guid Id { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(500)]
+    public string? Description { get; set; }
+}

--- a/ToDoTimeManager.Shared/DTOs/TeamMemberUpsertRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/TeamMemberUpsertRequestDto.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.Shared.Utils;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class TeamMemberUpsertRequestDto
+{
+    [NotEmptyGuid]
+    public Guid Id { get; set; }
+
+    [NotEmptyGuid]
+    public Guid TeamId { get; set; }
+
+    [NotEmptyGuid]
+    public Guid UserId { get; set; }
+
+    [Required]
+    public TeamMemberRole Role { get; set; }
+}

--- a/ToDoTimeManager.Shared/DTOs/TeamResponseDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/TeamResponseDto.cs
@@ -1,0 +1,14 @@
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class TeamResponseDto
+{
+    public Guid              Id          { get; set; }
+    public string            Name        { get; set; } = string.Empty;
+    public string?           Description { get; set; }
+    public DateTime          CreatedAt   { get; set; }
+    public Guid              CreatedBy   { get; set; }
+    public int               MemberCount { get; set; }
+    public List<TeamMember>? Members     { get; set; }
+}

--- a/ToDoTimeManager.Shared/DTOs/ToDoUpsertRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/ToDoUpsertRequestDto.cs
@@ -29,5 +29,7 @@ public sealed class ToDoUpsertRequestDto
     public ToDoStatus? Status { get; set; }
 
     public Guid? AssignedTo { get; set; }
+
+    public Guid? TeamId { get; set; }
 }
 

--- a/ToDoTimeManager.Shared/DTOs/UpdateTeamRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/UpdateTeamRequestDto.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Utils;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class UpdateTeamRequestDto
+{
+    [NotEmptyGuid]
+    public Guid Id { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(500)]
+    public string? Description { get; set; }
+}

--- a/ToDoTimeManager.Shared/Enums/TeamMemberRole.cs
+++ b/ToDoTimeManager.Shared/Enums/TeamMemberRole.cs
@@ -1,0 +1,7 @@
+namespace ToDoTimeManager.Shared.Enums;
+
+public enum TeamMemberRole
+{
+    Member = 0,
+    Owner  = 1
+}

--- a/ToDoTimeManager.Shared/Models/Team.cs
+++ b/ToDoTimeManager.Shared/Models/Team.cs
@@ -1,0 +1,11 @@
+namespace ToDoTimeManager.Shared.Models;
+
+public class Team
+{
+    public Guid    Id          { get; set; }
+    public string  Name        { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTime CreatedAt  { get; set; }
+    public Guid    CreatedBy   { get; set; }
+    public int     MemberCount { get; set; }
+}

--- a/ToDoTimeManager.Shared/Models/TeamMember.cs
+++ b/ToDoTimeManager.Shared/Models/TeamMember.cs
@@ -1,0 +1,11 @@
+using ToDoTimeManager.Shared.Enums;
+
+namespace ToDoTimeManager.Shared.Models;
+
+public class TeamMember
+{
+    public Guid           Id     { get; set; }
+    public Guid           TeamId { get; set; }
+    public Guid           UserId { get; set; }
+    public TeamMemberRole Role   { get; set; }
+}

--- a/ToDoTimeManager.Shared/Models/ToDo.cs
+++ b/ToDoTimeManager.Shared/Models/ToDo.cs
@@ -15,4 +15,5 @@ public class ToDo
 
     public ToDoStatus Status { get; set; } = ToDoStatus.New;
     public Guid? AssignedTo { get; set; }
+    public Guid? TeamId     { get; set; }
 }

--- a/ToDoTimeManager.WebApi/Controllers/TeamsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/TeamsController.cs
@@ -1,0 +1,139 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.WebApi.Services.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/[controller]")]
+public class TeamsController : ControllerBase
+{
+    private readonly ITeamsService _teamsService;
+    private readonly ILogger<TeamsController> _logger;
+
+    public TeamsController(ITeamsService teamsService, ILogger<TeamsController> logger)
+    {
+        _teamsService = teamsService;
+        _logger = logger;
+    }
+
+    private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+    private bool IsAdmin() => User.IsInRole("Admin");
+
+    // ── Admin only ──────────────────────────────────────────────────────────
+
+    [Authorize(Roles = "Admin")]
+    [HttpGet("GetAll")]
+    public async Task<IActionResult> GetAllTeams()
+    {
+        var teams = await _teamsService.GetAllTeams();
+        return Ok(teams);
+    }
+
+    [Authorize(Roles = "Admin")]
+    [HttpDelete("Delete/{id}")]
+    public async Task<IActionResult> DeleteTeam(Guid id)
+    {
+        if (id == Guid.Empty) return BadRequest("Invalid team ID");
+        var result = await _teamsService.DeleteTeam(id);
+        return result ? Ok(result) : BadRequest("Team could not be deleted");
+    }
+
+    // ── Admin or team member ────────────────────────────────────────────────
+
+    [HttpGet("GetById/{id}")]
+    public async Task<IActionResult> GetTeamById(Guid id)
+    {
+        if (id == Guid.Empty) return BadRequest("Invalid team ID");
+
+        var team = await _teamsService.GetTeamById(id);
+        if (team == null) return NotFound("Team was not found");
+
+        if (!IsAdmin())
+        {
+            var membership = await _teamsService.GetMembership(id, GetCurrentUserId());
+            if (membership == null) return Forbid();
+        }
+
+        return Ok(team);
+    }
+
+    [HttpGet("GetToDosByTeamId/{teamId}")]
+    public async Task<IActionResult> GetToDosByTeamId(Guid teamId)
+    {
+        if (teamId == Guid.Empty) return BadRequest("Invalid team ID");
+
+        if (!IsAdmin())
+        {
+            var membership = await _teamsService.GetMembership(teamId, GetCurrentUserId());
+            if (membership == null) return Forbid();
+        }
+
+        var todos = await _teamsService.GetToDosByTeamId(teamId);
+        return Ok(todos);
+    }
+
+    // ── Admin or team owner ─────────────────────────────────────────────────
+
+    [HttpPut("Update")]
+    public async Task<IActionResult> UpdateTeam([FromBody] UpdateTeamRequestDto request)
+    {
+        if (!IsAdmin())
+        {
+            var membership = await _teamsService.GetMembership(request.Id, GetCurrentUserId());
+            if (membership == null || membership.Role != TeamMemberRole.Owner) return Forbid();
+        }
+
+        var result = await _teamsService.UpdateTeam(request);
+        return result ? Ok(result) : BadRequest("Team could not be updated");
+    }
+
+    [HttpPost("AddMember")]
+    public async Task<IActionResult> AddMember([FromBody] TeamMemberUpsertRequestDto request)
+    {
+        if (!IsAdmin())
+        {
+            var membership = await _teamsService.GetMembership(request.TeamId, GetCurrentUserId());
+            if (membership == null || membership.Role != TeamMemberRole.Owner) return Forbid();
+        }
+
+        var result = await _teamsService.AddMember(request);
+        return result ? Ok(result) : BadRequest("Member could not be added (already exists or invalid data)");
+    }
+
+    [HttpDelete("RemoveMember/{teamId}/{userId}")]
+    public async Task<IActionResult> RemoveMember(Guid teamId, Guid userId)
+    {
+        if (teamId == Guid.Empty || userId == Guid.Empty)
+            return BadRequest("Invalid team or user ID");
+
+        if (!IsAdmin())
+        {
+            var membership = await _teamsService.GetMembership(teamId, GetCurrentUserId());
+            if (membership == null || membership.Role != TeamMemberRole.Owner) return Forbid();
+        }
+
+        var result = await _teamsService.RemoveMember(teamId, userId);
+        return result ? Ok(result) : BadRequest("Member could not be removed (last owner or not found)");
+    }
+
+    // ── Any authenticated user ──────────────────────────────────────────────
+
+    [HttpGet("GetMyTeams")]
+    public async Task<IActionResult> GetMyTeams()
+    {
+        var teams = await _teamsService.GetTeamsByUserId(GetCurrentUserId());
+        return Ok(teams);
+    }
+
+    [HttpPost("Create")]
+    public async Task<IActionResult> CreateTeam([FromBody] CreateTeamRequestDto request)
+    {
+        var result = await _teamsService.CreateTeam(request, GetCurrentUserId());
+        return result ? Ok(result) : BadRequest("Team could not be created");
+    }
+}

--- a/ToDoTimeManager.WebApi/Entities/TeamEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/TeamEntity.cs
@@ -1,0 +1,34 @@
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.WebApi.Entities;
+
+public class TeamEntity
+{
+    public TeamEntity() { }
+
+    public TeamEntity(Team team)
+    {
+        Id          = team.Id;
+        Name        = team.Name;
+        Description = team.Description;
+        CreatedAt   = team.CreatedAt;
+        CreatedBy   = team.CreatedBy;
+    }
+
+    public Guid     Id          { get; set; }
+    public string   Name        { get; set; } = string.Empty;
+    public string?  Description { get; set; }
+    public DateTime CreatedAt   { get; set; }
+    public Guid     CreatedBy   { get; set; }
+    public int      MemberCount { get; set; }
+
+    public Team ToTeam() => new()
+    {
+        Id          = Id,
+        Name        = Name,
+        Description = Description,
+        CreatedAt   = CreatedAt,
+        CreatedBy   = CreatedBy,
+        MemberCount = MemberCount
+    };
+}

--- a/ToDoTimeManager.WebApi/Entities/TeamMemberEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/TeamMemberEntity.cs
@@ -1,0 +1,30 @@
+using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.WebApi.Entities;
+
+public class TeamMemberEntity
+{
+    public TeamMemberEntity() { }
+
+    public TeamMemberEntity(TeamMember teamMember)
+    {
+        Id     = teamMember.Id;
+        TeamId = teamMember.TeamId;
+        UserId = teamMember.UserId;
+        Role   = teamMember.Role;
+    }
+
+    public Guid           Id     { get; set; }
+    public Guid           TeamId { get; set; }
+    public Guid           UserId { get; set; }
+    public TeamMemberRole Role   { get; set; }
+
+    public TeamMember ToTeamMember() => new()
+    {
+        Id     = Id,
+        TeamId = TeamId,
+        UserId = UserId,
+        Role   = Role
+    };
+}

--- a/ToDoTimeManager.WebApi/Entities/ToDoEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/ToDoEntity.cs
@@ -21,6 +21,7 @@ public class ToDoEntity
         Status = toDo.Status;
         AssignedTo = toDo.AssignedTo;
         NumberedId = toDo.NumberedId;
+        TeamId     = toDo.TeamId;
     }
 
     public Guid Id { get; set; }
@@ -32,19 +33,21 @@ public class ToDoEntity
     public DateTime? DueDate { get; set; }
     public ToDoStatus Status { get; set; }
     public Guid? AssignedTo { get; set; }
+    public Guid? TeamId     { get; set; }
 
     public ToDo ToToDo()
     {
         return new ToDo
         {
-            Id = Id,
-            Title = Title,
+            Id          = Id,
+            Title       = Title,
             Description = Description,
-            CreatedAt = CreatedAt,
-            DueDate = DueDate,
-            Status = Status,
-            AssignedTo = AssignedTo,
-            NumberedId = NumberedId
+            CreatedAt   = CreatedAt,
+            DueDate     = DueDate,
+            Status      = Status,
+            AssignedTo  = AssignedTo,
+            NumberedId  = NumberedId,
+            TeamId      = TeamId
         };
     }
 }

--- a/ToDoTimeManager.WebApi/Program.cs
+++ b/ToDoTimeManager.WebApi/Program.cs
@@ -37,12 +37,15 @@ public class Program
         builder.Services.AddScoped<IUsersDataController, UsersDataController>();
         builder.Services.AddScoped<IToDosDataController, ToDosDataController>();
         builder.Services.AddScoped<ITimeLogsDataController, TimeLogsDataController>();
+        builder.Services.AddScoped<ITeamsDataController, TeamsDataController>();
+        builder.Services.AddScoped<ITeamMembersDataController, TeamMembersDataController>();
 
         builder.Services.AddScoped<IUsersService, UsersService>();
         builder.Services.AddScoped<IToDosService, ToDosService>();
         builder.Services.AddScoped<ITimeLogsService, TimeLogsService>();
         builder.Services.AddScoped<IAuthService, AuthService>();
         builder.Services.AddScoped<IStatisticService, StatisticService>();
+        builder.Services.AddScoped<ITeamsService, TeamsService>();
 
         builder.Services.AddScoped<GlobalExceptionHandler>();
 

--- a/ToDoTimeManager.WebApi/Services/DataControllers/DbAccessServices/DbAccessService.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/DbAccessServices/DbAccessService.cs
@@ -88,6 +88,11 @@ public interface IDbAccessService
     /// <typeparamref name="TResult"/>.</returns>
     Task<List<TResult>> GetRecordsByParameters<TResult>(string procedureName, DynamicParameters parameters);
 
+    /// <summary>
+    /// Executes a stored procedure with the specified parameters (non-query — INSERT/UPDATE/DELETE).
+    /// </summary>
+    Task<int> ExecuteByParameters(string procedureName, DynamicParameters parameters);
+
     //Task<List<TResult>> GetRecordsAsync<T1, T2, T3, T4, TResult>(
     //    string procedureName,
     //    Func<T1, T2, T3, T4, TResult> map,
@@ -359,6 +364,19 @@ public class DbAccessService : IDbAccessService
         catch (Exception e)
         {
             throw new InvalidOperationException($"Error retrieving records using procedure '{procedureName}' with parameters: {e.Message}");
+        }
+    }
+
+    public async Task<int> ExecuteByParameters(string procedureName, DynamicParameters parameters)
+    {
+        try
+        {
+            await using var connection = new SqlConnection(GetConnectionString());
+            return await connection.ExecuteAsync(procedureName, parameters, commandType: CommandType.StoredProcedure);
+        }
+        catch (Exception e)
+        {
+            throw new InvalidOperationException($"Error executing procedure '{procedureName}' with parameters: {e.Message}");
         }
     }
 

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/TeamMembersDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/TeamMembersDataController.cs
@@ -1,0 +1,57 @@
+using Dapper;
+using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Services.DataControllers.DbAccessServices;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Implementation;
+
+public class TeamMembersDataController : ITeamMembersDataController
+{
+    private readonly IDbAccessService _dbAccessService;
+    private readonly ILogger<TeamMembersDataController> _logger;
+
+    public TeamMembersDataController(IDbAccessService dbAccessService, ILogger<TeamMembersDataController> logger)
+    {
+        _dbAccessService = dbAccessService;
+        _logger = logger;
+    }
+
+    public async Task<List<TeamMemberEntity>> GetMembersByTeamId(Guid teamId)
+    {
+        try { return await _dbAccessService.GetAllByParameter<TeamMemberEntity>("sp_TeamMembers_GetByTeamId", "TeamId", teamId); }
+        catch (Exception e) { _logger.LogError(e, e.Message); return []; }
+    }
+
+    public async Task<TeamMemberEntity?> GetMemberByTeamIdAndUserId(Guid teamId, Guid userId)
+    {
+        try
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("TeamId", teamId);
+            parameters.Add("UserId", userId);
+            var results = await _dbAccessService.GetRecordsByParameters<TeamMemberEntity>(
+                "sp_TeamMembers_GetByTeamIdAndUserId", parameters);
+            return results.FirstOrDefault();
+        }
+        catch (Exception e) { _logger.LogError(e, e.Message); return null; }
+    }
+
+    public async Task<bool> AddMember(TeamMemberEntity newMember)
+    {
+        try { return await _dbAccessService.AddRecord("sp_TeamMembers_Create", newMember) >= 1; }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+
+    public async Task<bool> RemoveMember(Guid teamId, Guid userId)
+    {
+        try
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("TeamId", teamId);
+            parameters.Add("UserId", userId);
+            return await _dbAccessService.ExecuteByParameters(
+                "sp_TeamMembers_DeleteByTeamIdAndUserId", parameters) >= 1;
+        }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/TeamsDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/TeamsDataController.cs
@@ -1,0 +1,53 @@
+using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Services.DataControllers.DbAccessServices;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Implementation;
+
+public class TeamsDataController : ITeamsDataController
+{
+    private readonly IDbAccessService _dbAccessService;
+    private readonly ILogger<TeamsDataController> _logger;
+
+    public TeamsDataController(IDbAccessService dbAccessService, ILogger<TeamsDataController> logger)
+    {
+        _dbAccessService = dbAccessService;
+        _logger = logger;
+    }
+
+    public async Task<List<TeamEntity>> GetAllTeams()
+    {
+        try { return await _dbAccessService.GetAllRecords<TeamEntity>("sp_Teams_GetAll"); }
+        catch (Exception e) { _logger.LogError(e, e.Message); return []; }
+    }
+
+    public async Task<TeamEntity?> GetTeamById(Guid teamId)
+    {
+        try { return await _dbAccessService.GetRecordById<TeamEntity>("sp_Teams_GetById", teamId); }
+        catch (Exception e) { _logger.LogError(e, e.Message); return null; }
+    }
+
+    public async Task<List<TeamEntity>> GetTeamsByUserId(Guid userId)
+    {
+        try { return await _dbAccessService.GetAllByParameter<TeamEntity>("sp_Teams_GetByUserId", "UserId", userId); }
+        catch (Exception e) { _logger.LogError(e, e.Message); return []; }
+    }
+
+    public async Task<bool> CreateTeam(TeamEntity newTeam)
+    {
+        try { return await _dbAccessService.AddRecord("sp_Teams_Create", newTeam) >= 1; }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+
+    public async Task<bool> UpdateTeam(TeamEntity updatedTeam)
+    {
+        try { return await _dbAccessService.UpdateRecord("sp_Teams_Update", updatedTeam) >= 1; }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+
+    public async Task<bool> DeleteTeam(Guid teamId)
+    {
+        try { return await _dbAccessService.DeleteRecordById("sp_Teams_DeleteById", teamId) >= 1; }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/ToDosDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/ToDosDataController.cs
@@ -129,4 +129,17 @@ public class ToDosDataController : IToDosDataController
             return [];
         }
     }
+
+    public async Task<List<ToDoEntity>> GetToDosByTeamId(Guid teamId)
+    {
+        try
+        {
+            return await _dbAccessService.GetAllByParameter<ToDoEntity>("sp_ToDos_GetByTeamId", "TeamId", teamId);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
 }

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/ITeamMembersDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/ITeamMembersDataController.cs
@@ -1,0 +1,11 @@
+using ToDoTimeManager.WebApi.Entities;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+public interface ITeamMembersDataController
+{
+    Task<List<TeamMemberEntity>> GetMembersByTeamId(Guid teamId);
+    Task<TeamMemberEntity?>      GetMemberByTeamIdAndUserId(Guid teamId, Guid userId);
+    Task<bool>                   AddMember(TeamMemberEntity newMember);
+    Task<bool>                   RemoveMember(Guid teamId, Guid userId);
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/ITeamsDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/ITeamsDataController.cs
@@ -1,0 +1,13 @@
+using ToDoTimeManager.WebApi.Entities;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+public interface ITeamsDataController
+{
+    Task<List<TeamEntity>> GetAllTeams();
+    Task<TeamEntity?>      GetTeamById(Guid teamId);
+    Task<List<TeamEntity>> GetTeamsByUserId(Guid userId);
+    Task<bool>             CreateTeam(TeamEntity newTeam);
+    Task<bool>             UpdateTeam(TeamEntity updatedTeam);
+    Task<bool>             DeleteTeam(Guid teamId);
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/IToDosDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/IToDosDataController.cs
@@ -14,4 +14,5 @@ public interface IToDosDataController
     Task<bool> UpdateToDo(ToDoEntity updatedToDo);
     Task<bool> DeleteToDo(Guid toDoId);
     Task<List<ToDo>> GetToDosByNearestDueDateByUserId(Guid filterUserId);
+    Task<List<ToDoEntity>> GetToDosByTeamId(Guid teamId);
 }

--- a/ToDoTimeManager.WebApi/Services/Implementations/TeamsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TeamsService.cs
@@ -1,0 +1,154 @@
+using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+using ToDoTimeManager.WebApi.Services.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.Implementations;
+
+public class TeamsService : ITeamsService
+{
+    private readonly ITeamsDataController _teamsDataController;
+    private readonly ITeamMembersDataController _teamMembersDataController;
+    private readonly IToDosDataController _toDosDataController;
+    private readonly ILogger<TeamsService> _logger;
+
+    public TeamsService(
+        ITeamsDataController teamsDataController,
+        ITeamMembersDataController teamMembersDataController,
+        IToDosDataController toDosDataController,
+        ILogger<TeamsService> logger)
+    {
+        _teamsDataController = teamsDataController;
+        _teamMembersDataController = teamMembersDataController;
+        _toDosDataController = toDosDataController;
+        _logger = logger;
+    }
+
+    public async Task<List<TeamResponseDto>> GetAllTeams()
+    {
+        var entities = await _teamsDataController.GetAllTeams();
+        return entities.Select(e => MapToDto(e.ToTeam(), null)).ToList();
+    }
+
+    public async Task<TeamResponseDto?> GetTeamById(Guid teamId)
+    {
+        var entity = await _teamsDataController.GetTeamById(teamId);
+        if (entity == null) return null;
+
+        var memberEntities = await _teamMembersDataController.GetMembersByTeamId(teamId);
+        var members = memberEntities.Select(m => m.ToTeamMember()).ToList();
+        return MapToDto(entity.ToTeam(), members);
+    }
+
+    public async Task<List<TeamResponseDto>> GetTeamsByUserId(Guid userId)
+    {
+        var entities = await _teamsDataController.GetTeamsByUserId(userId);
+        return entities.Select(e => MapToDto(e.ToTeam(), null)).ToList();
+    }
+
+    public async Task<bool> CreateTeam(CreateTeamRequestDto request, Guid createdByUserId)
+    {
+        var teamEntity = new TeamEntity
+        {
+            Id          = request.Id,
+            Name        = request.Name,
+            Description = request.Description,
+            CreatedAt   = DateTime.UtcNow,
+            CreatedBy   = createdByUserId
+        };
+
+        var teamCreated = await _teamsDataController.CreateTeam(teamEntity);
+        if (!teamCreated)
+        {
+            _logger.LogError("Failed to create team {TeamId}", request.Id);
+            return false;
+        }
+
+        var ownerMember = new TeamMemberEntity
+        {
+            Id     = Guid.NewGuid(),
+            TeamId = request.Id,
+            UserId = createdByUserId,
+            Role   = TeamMemberRole.Owner
+        };
+
+        var ownerAdded = await _teamMembersDataController.AddMember(ownerMember);
+        if (!ownerAdded)
+            _logger.LogError("Team {TeamId} created but failed to add owner {UserId}", request.Id, createdByUserId);
+
+        return ownerAdded;
+    }
+
+    public async Task<bool> UpdateTeam(UpdateTeamRequestDto request)
+    {
+        var entity = new TeamEntity
+        {
+            Id          = request.Id,
+            Name        = request.Name,
+            Description = request.Description
+        };
+        return await _teamsDataController.UpdateTeam(entity);
+    }
+
+    public async Task<bool> DeleteTeam(Guid teamId)
+    {
+        return await _teamsDataController.DeleteTeam(teamId);
+    }
+
+    public async Task<bool> AddMember(TeamMemberUpsertRequestDto request)
+    {
+        var existing = await _teamMembersDataController.GetMemberByTeamIdAndUserId(request.TeamId, request.UserId);
+        if (existing != null) return false;
+
+        var entity = new TeamMemberEntity
+        {
+            Id     = request.Id,
+            TeamId = request.TeamId,
+            UserId = request.UserId,
+            Role   = request.Role
+        };
+        return await _teamMembersDataController.AddMember(entity);
+    }
+
+    public async Task<bool> RemoveMember(Guid teamId, Guid userId)
+    {
+        var members = await _teamMembersDataController.GetMembersByTeamId(teamId);
+        var owners = members.Where(m => m.Role == TeamMemberRole.Owner).ToList();
+
+        var targetMember = members.FirstOrDefault(m => m.UserId == userId);
+        if (targetMember == null) return false;
+
+        if (targetMember.Role == TeamMemberRole.Owner && owners.Count == 1)
+        {
+            _logger.LogWarning("Cannot remove the last owner of team {TeamId}", teamId);
+            return false;
+        }
+
+        return await _teamMembersDataController.RemoveMember(teamId, userId);
+    }
+
+    public async Task<TeamMember?> GetMembership(Guid teamId, Guid userId)
+    {
+        var entity = await _teamMembersDataController.GetMemberByTeamIdAndUserId(teamId, userId);
+        return entity?.ToTeamMember();
+    }
+
+    public async Task<List<ToDo>> GetToDosByTeamId(Guid teamId)
+    {
+        var entities = await _toDosDataController.GetToDosByTeamId(teamId);
+        return entities.Select(e => e.ToToDo()).ToList();
+    }
+
+    private static TeamResponseDto MapToDto(Team team, List<TeamMember>? members) => new()
+    {
+        Id          = team.Id,
+        Name        = team.Name,
+        Description = team.Description,
+        CreatedAt   = team.CreatedAt,
+        CreatedBy   = team.CreatedBy,
+        MemberCount = team.MemberCount,
+        Members     = members
+    };
+}

--- a/ToDoTimeManager.WebApi/Services/Interfaces/ITeamsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/ITeamsService.cs
@@ -1,0 +1,18 @@
+using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.WebApi.Services.Interfaces;
+
+public interface ITeamsService
+{
+    Task<List<TeamResponseDto>> GetAllTeams();
+    Task<TeamResponseDto?>      GetTeamById(Guid teamId);
+    Task<List<TeamResponseDto>> GetTeamsByUserId(Guid userId);
+    Task<bool>                  CreateTeam(CreateTeamRequestDto request, Guid createdByUserId);
+    Task<bool>                  UpdateTeam(UpdateTeamRequestDto request);
+    Task<bool>                  DeleteTeam(Guid teamId);
+    Task<bool>                  AddMember(TeamMemberUpsertRequestDto request);
+    Task<bool>                  RemoveMember(Guid teamId, Guid userId);
+    Task<TeamMember?>           GetMembership(Guid teamId, Guid userId);
+    Task<List<ToDo>>            GetToDosByTeamId(Guid teamId);
+}


### PR DESCRIPTION
Implements a full team management backend following the existing 4-layer
architecture (Controller → Service → DataController → DbAccessService).

Database:
- New Teams table (Id, Name, Description, CreatedAt, CreatedBy FK→Users)
- New TeamMembers table (Id, TeamId FK→Teams, UserId FK→Users, Role INT)
  with UNIQUE constraint on (TeamId, UserId)
- ToDos table: added nullable TeamId FK→Teams column
- 6 new Teams stored procedures (GetAll/GetById/GetByUserId include
  MemberCount via COUNT JOIN; DeleteById cascades TeamMembers + nullifies ToDos)
- 5 new TeamMembers stored procedures
- 1 new sp_ToDos_GetByTeamId
- Updated 6 existing ToDos SPs to include TeamId column

Shared:
- TeamMemberRole enum (Member=0, Owner=1)
- Team and TeamMember models
- CreateTeamRequestDto, UpdateTeamRequestDto, TeamMemberUpsertRequestDto,
  TeamResponseDto (Members list null on list views, populated on GetById)
- ToDo model and ToDoUpsertRequestDto extended with nullable TeamId

WebApi:
- TeamEntity, TeamMemberEntity with To/From model conversion
- ToDoEntity extended with TeamId
- ITeamsDataController + TeamsDataController
- ITeamMembersDataController + TeamMembersDataController
- DbAccessService extended with ExecuteByParameters (for composite-key DELETE)
- IToDosDataController + ToDosDataController extended with GetToDosByTeamId
- ITeamsService + TeamsService with business rules:
  creator auto-assigned as Owner, duplicate member guard, last-owner removal guard
- TeamsController at api/Teams with 9 endpoints and role/ownership authorization

https://claude.ai/code/session_01QocpuX5fmzqPpehxkDT5n4