### PR TITLE
feat: implement Projects backend with team-based access control

### DIFF
--- a/ToDoTimeManager.DataBase/StoredProcedures/ProjectTeams/sp_ProjectTeams_Create.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ProjectTeams/sp_ProjectTeams_Create.sql
@@ -1,0 +1,10 @@
+CREATE PROCEDURE [dbo].[sp_ProjectTeams_Create]
+    @Id        UNIQUEIDENTIFIER,
+    @ProjectId UNIQUEIDENTIFIER,
+    @TeamId    UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    INSERT INTO [dbo].[ProjectTeams] (Id, ProjectId, TeamId)
+    VALUES (@Id, @ProjectId, @TeamId);
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ProjectTeams/sp_ProjectTeams_DeleteByProjectIdAndTeamId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ProjectTeams/sp_ProjectTeams_DeleteByProjectIdAndTeamId.sql
@@ -1,0 +1,9 @@
+CREATE PROCEDURE [dbo].[sp_ProjectTeams_DeleteByProjectIdAndTeamId]
+    @ProjectId UNIQUEIDENTIFIER,
+    @TeamId    UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DELETE FROM [dbo].[ProjectTeams]
+    WHERE ProjectId = @ProjectId AND TeamId = @TeamId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ProjectTeams/sp_ProjectTeams_GetByProjectId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ProjectTeams/sp_ProjectTeams_GetByProjectId.sql
@@ -1,0 +1,9 @@
+CREATE PROCEDURE [dbo].[sp_ProjectTeams_GetByProjectId]
+    @ProjectId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT Id, ProjectId, TeamId
+    FROM [dbo].[ProjectTeams]
+    WHERE ProjectId = @ProjectId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ProjectTeams/sp_ProjectTeams_GetByProjectIdAndTeamId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ProjectTeams/sp_ProjectTeams_GetByProjectIdAndTeamId.sql
@@ -1,0 +1,10 @@
+CREATE PROCEDURE [dbo].[sp_ProjectTeams_GetByProjectIdAndTeamId]
+    @ProjectId UNIQUEIDENTIFIER,
+    @TeamId    UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT Id, ProjectId, TeamId
+    FROM [dbo].[ProjectTeams]
+    WHERE ProjectId = @ProjectId AND TeamId = @TeamId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_Create.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_Create.sql
@@ -1,0 +1,12 @@
+CREATE PROCEDURE [dbo].[sp_Projects_Create]
+    @Id          UNIQUEIDENTIFIER,
+    @Name        NVARCHAR(100),
+    @Description NVARCHAR(500),
+    @CreatedAt   DATETIME,
+    @CreatedBy   UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    INSERT INTO [dbo].[Projects] (Id, Name, Description, CreatedAt, CreatedBy)
+    VALUES (@Id, @Name, @Description, @CreatedAt, @CreatedBy);
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_DeleteById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_DeleteById.sql
@@ -1,0 +1,16 @@
+CREATE PROCEDURE [dbo].[sp_Projects_DeleteById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE [dbo].[ToDos]
+    SET ProjectId = NULL
+    WHERE ProjectId = @Id;
+
+    DELETE FROM [dbo].[ProjectTeams]
+    WHERE ProjectId = @Id;
+
+    DELETE FROM [dbo].[Projects]
+    WHERE Id = @Id;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetAll.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetAll.sql
@@ -1,0 +1,16 @@
+CREATE PROCEDURE [dbo].[sp_Projects_GetAll]
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT
+        p.Id,
+        p.Name,
+        p.Description,
+        p.CreatedAt,
+        p.CreatedBy,
+        COUNT(pt.Id) AS TeamCount
+    FROM [dbo].[Projects] p
+    LEFT JOIN [dbo].[ProjectTeams] pt ON pt.ProjectId = p.Id
+    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy
+    ORDER BY p.Name ASC;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetById.sql
@@ -1,0 +1,17 @@
+CREATE PROCEDURE [dbo].[sp_Projects_GetById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT
+        p.Id,
+        p.Name,
+        p.Description,
+        p.CreatedAt,
+        p.CreatedBy,
+        COUNT(pt.Id) AS TeamCount
+    FROM [dbo].[Projects] p
+    LEFT JOIN [dbo].[ProjectTeams] pt ON pt.ProjectId = p.Id
+    WHERE p.Id = @Id
+    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetByUserId.sql
@@ -1,0 +1,19 @@
+CREATE PROCEDURE [dbo].[sp_Projects_GetByUserId]
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT DISTINCT
+        p.Id,
+        p.Name,
+        p.Description,
+        p.CreatedAt,
+        p.CreatedBy,
+        COUNT(pt2.Id) AS TeamCount
+    FROM [dbo].[Projects] p
+    INNER JOIN [dbo].[ProjectTeams] pt  ON pt.ProjectId  = p.Id
+    INNER JOIN [dbo].[TeamMembers]  tm  ON tm.TeamId     = pt.TeamId AND tm.UserId = @UserId
+    LEFT  JOIN [dbo].[ProjectTeams] pt2 ON pt2.ProjectId = p.Id
+    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy
+    ORDER BY p.Name ASC;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_Update.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_Update.sql
@@ -1,0 +1,12 @@
+CREATE PROCEDURE [dbo].[sp_Projects_Update]
+    @Id          UNIQUEIDENTIFIER,
+    @Name        NVARCHAR(100),
+    @Description NVARCHAR(500)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE [dbo].[Projects]
+    SET Name        = @Name,
+        Description = @Description
+    WHERE Id = @Id;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Create.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Create.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[sp_ToDos_Create]
+CREATE PROCEDURE [dbo].[sp_ToDos_Create]
 	@Id          UNIQUEIDENTIFIER,
 	@NumberedId  INT,
 	@Title       NVARCHAR(100),
@@ -7,7 +7,8 @@
 	@DueDate     DATETIME,
 	@Status      INT,
 	@AssignedTo  UNIQUEIDENTIFIER,
-	@TeamId      UNIQUEIDENTIFIER
+	@TeamId      UNIQUEIDENTIFIER,
+	@ProjectId   UNIQUEIDENTIFIER
 AS
 	INSERT INTO [dbo].[ToDos] (
 		Id,
@@ -18,7 +19,8 @@ AS
 		Status,
 		AssignedTo,
 		NumberedId,
-		TeamId
+		TeamId,
+		ProjectId
 	)
 	VALUES (
 		@Id,
@@ -29,5 +31,6 @@ AS
 		@Status,
 		@AssignedTo,
 		(SELECT ISNULL(MAX(NumberedId), 0) + 1 FROM [dbo].[ToDos]),
-		@TeamId
+		@TeamId,
+		@ProjectId
 	)

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetAll.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetAll.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[sp_ToDos_GetAll]
+CREATE PROCEDURE [dbo].[sp_ToDos_GetAll]
 AS
 	SELECT
 		Id,
@@ -9,6 +9,7 @@ AS
 		Status,
 		AssignedTo,
 		NumberedId,
-		TeamId
+		TeamId,
+		ProjectId
 	FROM
 		[dbo].[ToDos]

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByAssignedTo.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByAssignedTo.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[sp_ToDos_GetByAssignedTo]
+CREATE PROCEDURE [dbo].[sp_ToDos_GetByAssignedTo]
 	@AssignedTo UNIQUEIDENTIFIER
 AS
 	SELECT
@@ -10,7 +10,7 @@ AS
 		Status,
 		AssignedTo,
 		NumberedId,
-		TeamId
+		TeamId,
+		ProjectId
 	FROM [dbo].[ToDos]
 	WHERE AssignedTo = @AssignedTo
-

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetById.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[sp_ToDos_GetById]
+CREATE PROCEDURE [dbo].[sp_ToDos_GetById]
 	@Id UNIQUEIDENTIFIER
 AS
 	SELECT
@@ -10,6 +10,7 @@ AS
 		Status,
 		AssignedTo,
 		NumberedId,
-		TeamId
+		TeamId,
+		ProjectId
 	FROM [dbo].[ToDos]
 	WHERE Id = @Id

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByNearestDueDateByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByNearestDueDateByUserId.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[sp_ToDos_GetByNearestDueDateByUserId]
+CREATE PROCEDURE [dbo].[sp_ToDos_GetByNearestDueDateByUserId]
 @UserId UNIQUEIDENTIFIER
 AS
 BEGIN
@@ -13,7 +13,8 @@ BEGIN
         Status,
         AssignedTo,
         NumberedId,
-        TeamId
+        TeamId,
+        ProjectId
     FROM [dbo].[ToDos]
     WHERE AssignedTo = @UserId
       AND DueDate IS NOT NULL

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByProjectId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByProjectId.sql
@@ -1,5 +1,5 @@
-CREATE PROCEDURE [dbo].[sp_ToDos_GetByTeamId]
-    @TeamId UNIQUEIDENTIFIER
+CREATE PROCEDURE [dbo].[sp_ToDos_GetByProjectId]
+    @ProjectId UNIQUEIDENTIFIER
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -15,5 +15,5 @@ BEGIN
         TeamId,
         ProjectId
     FROM [dbo].[ToDos]
-    WHERE TeamId = @TeamId;
+    WHERE ProjectId = @ProjectId;
 END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Update.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Update.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[sp_ToDos_Update]
+CREATE PROCEDURE [dbo].[sp_ToDos_Update]
     @Id          UNIQUEIDENTIFIER,
     @Title       NVARCHAR(100),
     @Description NVARCHAR(MAX),
@@ -7,7 +7,8 @@
     @Status      INT,
     @AssignedTo  UNIQUEIDENTIFIER,
     @NumberedId  INT,
-    @TeamId      UNIQUEIDENTIFIER
+    @TeamId      UNIQUEIDENTIFIER,
+    @ProjectId   UNIQUEIDENTIFIER
 AS
     UPDATE [dbo].[ToDos]
     SET
@@ -17,6 +18,7 @@ AS
         DueDate     = @DueDate,
         Status      = @Status,
         AssignedTo  = @AssignedTo,
-        TeamId      = @TeamId
+        TeamId      = @TeamId,
+        ProjectId   = @ProjectId
     WHERE
         Id = @Id

--- a/ToDoTimeManager.DataBase/Tables/ProjectTeams.sql
+++ b/ToDoTimeManager.DataBase/Tables/ProjectTeams.sql
@@ -1,0 +1,9 @@
+CREATE TABLE [dbo].[ProjectTeams]
+(
+    Id        UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
+    ProjectId UNIQUEIDENTIFIER NOT NULL,
+    TeamId    UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT [FK_ProjectTeams_Projects] FOREIGN KEY ([ProjectId]) REFERENCES [Projects]([Id]),
+    CONSTRAINT [FK_ProjectTeams_Teams]    FOREIGN KEY ([TeamId])    REFERENCES [Teams]([Id]),
+    CONSTRAINT [UQ_ProjectTeams_ProjectId_TeamId] UNIQUE ([ProjectId], [TeamId])
+)

--- a/ToDoTimeManager.DataBase/Tables/Projects.sql
+++ b/ToDoTimeManager.DataBase/Tables/Projects.sql
@@ -1,0 +1,9 @@
+CREATE TABLE [dbo].[Projects]
+(
+    Id          UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
+    Name        NVARCHAR(100)    NOT NULL,
+    Description NVARCHAR(500)    NULL,
+    CreatedAt   DATETIME         NOT NULL,
+    CreatedBy   UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT [FK_Projects_Users_CreatedBy] FOREIGN KEY ([CreatedBy]) REFERENCES [Users]([Id])
+)

--- a/ToDoTimeManager.DataBase/Tables/ToDos.sql
+++ b/ToDoTimeManager.DataBase/Tables/ToDos.sql
@@ -9,6 +9,8 @@
     Status INT NOT NULL,
     AssignedTo UNIQUEIDENTIFIER NULL,
     TeamId     UNIQUEIDENTIFIER NULL,
-    CONSTRAINT [FK_ToDos_Users]  FOREIGN KEY ([AssignedTo]) REFERENCES [Users]([Id]),
-    CONSTRAINT [FK_ToDos_Teams]  FOREIGN KEY ([TeamId])     REFERENCES [Teams]([Id])
+    ProjectId  UNIQUEIDENTIFIER NULL,
+    CONSTRAINT [FK_ToDos_Users]    FOREIGN KEY ([AssignedTo]) REFERENCES [Users]([Id]),
+    CONSTRAINT [FK_ToDos_Teams]    FOREIGN KEY ([TeamId])     REFERENCES [Teams]([Id]),
+    CONSTRAINT [FK_ToDos_Projects] FOREIGN KEY ([ProjectId])  REFERENCES [Projects]([Id])
 )

--- a/ToDoTimeManager.Shared/DTOs/CreateProjectRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/CreateProjectRequestDto.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Utils;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class CreateProjectRequestDto
+{
+    [NotEmptyGuid]
+    public Guid Id { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(500)]
+    public string? Description { get; set; }
+}

--- a/ToDoTimeManager.Shared/DTOs/ProjectResponseDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/ProjectResponseDto.cs
@@ -1,0 +1,14 @@
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class ProjectResponseDto
+{
+    public Guid                Id          { get; set; }
+    public string              Name        { get; set; } = string.Empty;
+    public string?             Description { get; set; }
+    public DateTime            CreatedAt   { get; set; }
+    public Guid                CreatedBy   { get; set; }
+    public int                 TeamCount   { get; set; }
+    public List<ProjectTeam>?  Teams       { get; set; }
+}

--- a/ToDoTimeManager.Shared/DTOs/ProjectTeamUpsertRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/ProjectTeamUpsertRequestDto.cs
@@ -1,0 +1,15 @@
+using ToDoTimeManager.Shared.Utils;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class ProjectTeamUpsertRequestDto
+{
+    [NotEmptyGuid]
+    public Guid Id { get; set; }
+
+    [NotEmptyGuid]
+    public Guid ProjectId { get; set; }
+
+    [NotEmptyGuid]
+    public Guid TeamId { get; set; }
+}

--- a/ToDoTimeManager.Shared/DTOs/ToDoUpsertRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/ToDoUpsertRequestDto.cs
@@ -31,5 +31,7 @@ public sealed class ToDoUpsertRequestDto
     public Guid? AssignedTo { get; set; }
 
     public Guid? TeamId { get; set; }
+
+    public Guid? ProjectId { get; set; }
 }
 

--- a/ToDoTimeManager.Shared/DTOs/UpdateProjectRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/UpdateProjectRequestDto.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Utils;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public sealed class UpdateProjectRequestDto
+{
+    [NotEmptyGuid]
+    public Guid Id { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(500)]
+    public string? Description { get; set; }
+}

--- a/ToDoTimeManager.Shared/Models/Project.cs
+++ b/ToDoTimeManager.Shared/Models/Project.cs
@@ -1,0 +1,11 @@
+namespace ToDoTimeManager.Shared.Models;
+
+public class Project
+{
+    public Guid     Id          { get; set; }
+    public string   Name        { get; set; } = string.Empty;
+    public string?  Description { get; set; }
+    public DateTime CreatedAt   { get; set; }
+    public Guid     CreatedBy   { get; set; }
+    public int      TeamCount   { get; set; }
+}

--- a/ToDoTimeManager.Shared/Models/ProjectTeam.cs
+++ b/ToDoTimeManager.Shared/Models/ProjectTeam.cs
@@ -1,0 +1,8 @@
+namespace ToDoTimeManager.Shared.Models;
+
+public class ProjectTeam
+{
+    public Guid Id        { get; set; }
+    public Guid ProjectId { get; set; }
+    public Guid TeamId    { get; set; }
+}

--- a/ToDoTimeManager.Shared/Models/ToDo.cs
+++ b/ToDoTimeManager.Shared/Models/ToDo.cs
@@ -16,4 +16,5 @@ public class ToDo
     public ToDoStatus Status { get; set; } = ToDoStatus.New;
     public Guid? AssignedTo { get; set; }
     public Guid? TeamId     { get; set; }
+    public Guid? ProjectId  { get; set; }
 }

--- a/ToDoTimeManager.WebApi/Controllers/ProjectsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/ProjectsController.cs
@@ -1,0 +1,135 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.WebApi.Services.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/[controller]")]
+public class ProjectsController : ControllerBase
+{
+    private readonly IProjectsService _projectsService;
+    private readonly ILogger<ProjectsController> _logger;
+
+    public ProjectsController(IProjectsService projectsService, ILogger<ProjectsController> logger)
+    {
+        _projectsService = projectsService;
+        _logger = logger;
+    }
+
+    private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+    private bool IsAdmin() => User.IsInRole("Admin");
+
+    // ── Admin only ──────────────────────────────────────────────────────────
+
+    [Authorize(Roles = "Admin")]
+    [HttpGet("GetAll")]
+    public async Task<IActionResult> GetAllProjects()
+    {
+        var projects = await _projectsService.GetAllProjects();
+        return Ok(projects);
+    }
+
+    [Authorize(Roles = "Admin")]
+    [HttpDelete("Delete/{id}")]
+    public async Task<IActionResult> DeleteProject(Guid id)
+    {
+        if (id == Guid.Empty) return BadRequest("Invalid project ID");
+        var result = await _projectsService.DeleteProject(id);
+        return result ? Ok(result) : BadRequest("Project could not be deleted");
+    }
+
+    // ── Admin or project-accessible user (read) ─────────────────────────────
+
+    [HttpGet("GetById/{id}")]
+    public async Task<IActionResult> GetProjectById(Guid id)
+    {
+        if (id == Guid.Empty) return BadRequest("Invalid project ID");
+
+        var project = await _projectsService.GetProjectById(id);
+        if (project == null) return NotFound("Project was not found");
+
+        if (!IsAdmin() && !await _projectsService.UserHasAccessToProject(id, GetCurrentUserId()))
+            return Forbid();
+
+        return Ok(project);
+    }
+
+    [HttpGet("GetToDosByProjectId/{projectId}")]
+    public async Task<IActionResult> GetToDosByProjectId(Guid projectId)
+    {
+        if (projectId == Guid.Empty) return BadRequest("Invalid project ID");
+
+        if (!IsAdmin() && !await _projectsService.UserHasAccessToProject(projectId, GetCurrentUserId()))
+            return Forbid();
+
+        var todos = await _projectsService.GetToDosByProjectId(projectId);
+        return Ok(todos);
+    }
+
+    // ── Admin or project owner (writes) ────────────────────────────────────
+
+    [HttpPut("Update")]
+    public async Task<IActionResult> UpdateProject([FromBody] UpdateProjectRequestDto request)
+    {
+        if (!IsAdmin())
+        {
+            var project = await _projectsService.GetProjectById(request.Id);
+            if (project == null) return NotFound("Project was not found");
+            if (project.CreatedBy != GetCurrentUserId()) return Forbid();
+        }
+
+        var result = await _projectsService.UpdateProject(request);
+        return result ? Ok(result) : BadRequest("Project could not be updated");
+    }
+
+    [HttpPost("AddTeam")]
+    public async Task<IActionResult> AddTeam([FromBody] ProjectTeamUpsertRequestDto request)
+    {
+        if (!IsAdmin())
+        {
+            var project = await _projectsService.GetProjectById(request.ProjectId);
+            if (project == null) return NotFound("Project was not found");
+            if (project.CreatedBy != GetCurrentUserId()) return Forbid();
+        }
+
+        var result = await _projectsService.AddTeam(request);
+        return result ? Ok(result) : BadRequest("Team could not be added (already linked or invalid data)");
+    }
+
+    [HttpDelete("RemoveTeam/{projectId}/{teamId}")]
+    public async Task<IActionResult> RemoveTeam(Guid projectId, Guid teamId)
+    {
+        if (projectId == Guid.Empty || teamId == Guid.Empty)
+            return BadRequest("Invalid project or team ID");
+
+        if (!IsAdmin())
+        {
+            var project = await _projectsService.GetProjectById(projectId);
+            if (project == null) return NotFound("Project was not found");
+            if (project.CreatedBy != GetCurrentUserId()) return Forbid();
+        }
+
+        var result = await _projectsService.RemoveTeam(projectId, teamId);
+        return result ? Ok(result) : BadRequest("Team could not be removed");
+    }
+
+    // ── Any authenticated user ──────────────────────────────────────────────
+
+    [HttpGet("GetMyProjects")]
+    public async Task<IActionResult> GetMyProjects()
+    {
+        var projects = await _projectsService.GetProjectsByUserId(GetCurrentUserId());
+        return Ok(projects);
+    }
+
+    [HttpPost("Create")]
+    public async Task<IActionResult> CreateProject([FromBody] CreateProjectRequestDto request)
+    {
+        var result = await _projectsService.CreateProject(request, GetCurrentUserId());
+        return result ? Ok(result) : BadRequest("Project could not be created");
+    }
+}

--- a/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
@@ -60,14 +60,16 @@ public class ToDosController : ControllerBase
     {
         var toDo = new ToDo
         {
-            Id = request.Id,
-            NumberedId = request.NumberedId,
-            Title = request.Title,
+            Id          = request.Id,
+            NumberedId  = request.NumberedId,
+            Title       = request.Title,
             Description = request.Description,
-            CreatedAt = request.CreatedAt!.Value,
-            DueDate = request.DueDate,
-            Status = request.Status!.Value,
-            AssignedTo = request.AssignedTo
+            CreatedAt   = request.CreatedAt!.Value,
+            DueDate     = request.DueDate,
+            Status      = request.Status!.Value,
+            AssignedTo  = request.AssignedTo,
+            TeamId      = request.TeamId,
+            ProjectId   = request.ProjectId
         };
 
         var newToDo = await _toDosService.CreateToDo(toDo);
@@ -84,14 +86,16 @@ public class ToDosController : ControllerBase
 
         var toDo = new ToDo
         {
-            Id = request.Id,
-            NumberedId = request.NumberedId,
-            Title = request.Title,
+            Id          = request.Id,
+            NumberedId  = request.NumberedId,
+            Title       = request.Title,
             Description = request.Description,
-            CreatedAt = request.CreatedAt!.Value,
-            DueDate = request.DueDate,
-            Status = request.Status!.Value,
-            AssignedTo = request.AssignedTo
+            CreatedAt   = request.CreatedAt!.Value,
+            DueDate     = request.DueDate,
+            Status      = request.Status!.Value,
+            AssignedTo  = request.AssignedTo,
+            TeamId      = request.TeamId,
+            ProjectId   = request.ProjectId
         };
 
         var updatedToDo = await _toDosService.UpdateToDo(toDo);

--- a/ToDoTimeManager.WebApi/Entities/ProjectEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/ProjectEntity.cs
@@ -1,0 +1,34 @@
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.WebApi.Entities;
+
+public class ProjectEntity
+{
+    public ProjectEntity() { }
+
+    public ProjectEntity(Project project)
+    {
+        Id          = project.Id;
+        Name        = project.Name;
+        Description = project.Description;
+        CreatedAt   = project.CreatedAt;
+        CreatedBy   = project.CreatedBy;
+    }
+
+    public Guid     Id          { get; set; }
+    public string   Name        { get; set; } = string.Empty;
+    public string?  Description { get; set; }
+    public DateTime CreatedAt   { get; set; }
+    public Guid     CreatedBy   { get; set; }
+    public int      TeamCount   { get; set; }
+
+    public Project ToProject() => new()
+    {
+        Id          = Id,
+        Name        = Name,
+        Description = Description,
+        CreatedAt   = CreatedAt,
+        CreatedBy   = CreatedBy,
+        TeamCount   = TeamCount
+    };
+}

--- a/ToDoTimeManager.WebApi/Entities/ProjectTeamEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/ProjectTeamEntity.cs
@@ -1,0 +1,19 @@
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.WebApi.Entities;
+
+public class ProjectTeamEntity
+{
+    public ProjectTeamEntity() { }
+
+    public Guid Id        { get; set; }
+    public Guid ProjectId { get; set; }
+    public Guid TeamId    { get; set; }
+
+    public ProjectTeam ToProjectTeam() => new()
+    {
+        Id        = Id,
+        ProjectId = ProjectId,
+        TeamId    = TeamId
+    };
+}

--- a/ToDoTimeManager.WebApi/Entities/ToDoEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/ToDoEntity.cs
@@ -22,6 +22,7 @@ public class ToDoEntity
         AssignedTo = toDo.AssignedTo;
         NumberedId = toDo.NumberedId;
         TeamId     = toDo.TeamId;
+        ProjectId  = toDo.ProjectId;
     }
 
     public Guid Id { get; set; }
@@ -34,6 +35,7 @@ public class ToDoEntity
     public ToDoStatus Status { get; set; }
     public Guid? AssignedTo { get; set; }
     public Guid? TeamId     { get; set; }
+    public Guid? ProjectId  { get; set; }
 
     public ToDo ToToDo()
     {
@@ -47,7 +49,8 @@ public class ToDoEntity
             Status      = Status,
             AssignedTo  = AssignedTo,
             NumberedId  = NumberedId,
-            TeamId      = TeamId
+            TeamId      = TeamId,
+            ProjectId   = ProjectId
         };
     }
 }

--- a/ToDoTimeManager.WebApi/Program.cs
+++ b/ToDoTimeManager.WebApi/Program.cs
@@ -39,6 +39,8 @@ public class Program
         builder.Services.AddScoped<ITimeLogsDataController, TimeLogsDataController>();
         builder.Services.AddScoped<ITeamsDataController, TeamsDataController>();
         builder.Services.AddScoped<ITeamMembersDataController, TeamMembersDataController>();
+        builder.Services.AddScoped<IProjectsDataController, ProjectsDataController>();
+        builder.Services.AddScoped<IProjectTeamsDataController, ProjectTeamsDataController>();
 
         builder.Services.AddScoped<IUsersService, UsersService>();
         builder.Services.AddScoped<IToDosService, ToDosService>();
@@ -46,6 +48,7 @@ public class Program
         builder.Services.AddScoped<IAuthService, AuthService>();
         builder.Services.AddScoped<IStatisticService, StatisticService>();
         builder.Services.AddScoped<ITeamsService, TeamsService>();
+        builder.Services.AddScoped<IProjectsService, ProjectsService>();
 
         builder.Services.AddScoped<GlobalExceptionHandler>();
 

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/ProjectTeamsDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/ProjectTeamsDataController.cs
@@ -1,0 +1,57 @@
+using Dapper;
+using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Services.DataControllers.DbAccessServices;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Implementation;
+
+public class ProjectTeamsDataController : IProjectTeamsDataController
+{
+    private readonly IDbAccessService _dbAccessService;
+    private readonly ILogger<ProjectTeamsDataController> _logger;
+
+    public ProjectTeamsDataController(IDbAccessService dbAccessService, ILogger<ProjectTeamsDataController> logger)
+    {
+        _dbAccessService = dbAccessService;
+        _logger = logger;
+    }
+
+    public async Task<List<ProjectTeamEntity>> GetTeamsByProjectId(Guid projectId)
+    {
+        try { return await _dbAccessService.GetAllByParameter<ProjectTeamEntity>("sp_ProjectTeams_GetByProjectId", "ProjectId", projectId); }
+        catch (Exception e) { _logger.LogError(e, e.Message); return []; }
+    }
+
+    public async Task<ProjectTeamEntity?> GetByProjectIdAndTeamId(Guid projectId, Guid teamId)
+    {
+        try
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("ProjectId", projectId);
+            parameters.Add("TeamId", teamId);
+            var results = await _dbAccessService.GetRecordsByParameters<ProjectTeamEntity>(
+                "sp_ProjectTeams_GetByProjectIdAndTeamId", parameters);
+            return results.FirstOrDefault();
+        }
+        catch (Exception e) { _logger.LogError(e, e.Message); return null; }
+    }
+
+    public async Task<bool> AddTeam(ProjectTeamEntity newProjectTeam)
+    {
+        try { return await _dbAccessService.AddRecord("sp_ProjectTeams_Create", newProjectTeam) >= 1; }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+
+    public async Task<bool> RemoveTeam(Guid projectId, Guid teamId)
+    {
+        try
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("ProjectId", projectId);
+            parameters.Add("TeamId", teamId);
+            return await _dbAccessService.ExecuteByParameters(
+                "sp_ProjectTeams_DeleteByProjectIdAndTeamId", parameters) >= 1;
+        }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/ProjectsDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/ProjectsDataController.cs
@@ -1,0 +1,53 @@
+using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Services.DataControllers.DbAccessServices;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Implementation;
+
+public class ProjectsDataController : IProjectsDataController
+{
+    private readonly IDbAccessService _dbAccessService;
+    private readonly ILogger<ProjectsDataController> _logger;
+
+    public ProjectsDataController(IDbAccessService dbAccessService, ILogger<ProjectsDataController> logger)
+    {
+        _dbAccessService = dbAccessService;
+        _logger = logger;
+    }
+
+    public async Task<List<ProjectEntity>> GetAllProjects()
+    {
+        try { return await _dbAccessService.GetAllRecords<ProjectEntity>("sp_Projects_GetAll"); }
+        catch (Exception e) { _logger.LogError(e, e.Message); return []; }
+    }
+
+    public async Task<ProjectEntity?> GetProjectById(Guid projectId)
+    {
+        try { return await _dbAccessService.GetRecordById<ProjectEntity>("sp_Projects_GetById", projectId); }
+        catch (Exception e) { _logger.LogError(e, e.Message); return null; }
+    }
+
+    public async Task<List<ProjectEntity>> GetProjectsByUserId(Guid userId)
+    {
+        try { return await _dbAccessService.GetAllByParameter<ProjectEntity>("sp_Projects_GetByUserId", "UserId", userId); }
+        catch (Exception e) { _logger.LogError(e, e.Message); return []; }
+    }
+
+    public async Task<bool> CreateProject(ProjectEntity newProject)
+    {
+        try { return await _dbAccessService.AddRecord("sp_Projects_Create", newProject) >= 1; }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+
+    public async Task<bool> UpdateProject(ProjectEntity updatedProject)
+    {
+        try { return await _dbAccessService.UpdateRecord("sp_Projects_Update", updatedProject) >= 1; }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+
+    public async Task<bool> DeleteProject(Guid projectId)
+    {
+        try { return await _dbAccessService.DeleteRecordById("sp_Projects_DeleteById", projectId) >= 1; }
+        catch (Exception e) { _logger.LogError(e, e.Message); return false; }
+    }
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/ToDosDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/ToDosDataController.cs
@@ -142,4 +142,17 @@ public class ToDosDataController : IToDosDataController
             return [];
         }
     }
+
+    public async Task<List<ToDoEntity>> GetToDosByProjectId(Guid projectId)
+    {
+        try
+        {
+            return await _dbAccessService.GetAllByParameter<ToDoEntity>("sp_ToDos_GetByProjectId", "ProjectId", projectId);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
 }

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/IProjectTeamsDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/IProjectTeamsDataController.cs
@@ -1,0 +1,11 @@
+using ToDoTimeManager.WebApi.Entities;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+public interface IProjectTeamsDataController
+{
+    Task<List<ProjectTeamEntity>> GetTeamsByProjectId(Guid projectId);
+    Task<ProjectTeamEntity?>      GetByProjectIdAndTeamId(Guid projectId, Guid teamId);
+    Task<bool>                    AddTeam(ProjectTeamEntity newProjectTeam);
+    Task<bool>                    RemoveTeam(Guid projectId, Guid teamId);
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/IProjectsDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/IProjectsDataController.cs
@@ -1,0 +1,13 @@
+using ToDoTimeManager.WebApi.Entities;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+public interface IProjectsDataController
+{
+    Task<List<ProjectEntity>> GetAllProjects();
+    Task<ProjectEntity?>      GetProjectById(Guid projectId);
+    Task<List<ProjectEntity>> GetProjectsByUserId(Guid userId);
+    Task<bool>                CreateProject(ProjectEntity newProject);
+    Task<bool>                UpdateProject(ProjectEntity updatedProject);
+    Task<bool>                DeleteProject(Guid projectId);
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/IToDosDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/IToDosDataController.cs
@@ -15,4 +15,5 @@ public interface IToDosDataController
     Task<bool> DeleteToDo(Guid toDoId);
     Task<List<ToDo>> GetToDosByNearestDueDateByUserId(Guid filterUserId);
     Task<List<ToDoEntity>> GetToDosByTeamId(Guid teamId);
+    Task<List<ToDoEntity>> GetToDosByProjectId(Guid projectId);
 }

--- a/ToDoTimeManager.WebApi/Services/Implementations/ProjectsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/ProjectsService.cs
@@ -1,0 +1,126 @@
+using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+using ToDoTimeManager.WebApi.Services.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.Implementations;
+
+public class ProjectsService : IProjectsService
+{
+    private readonly IProjectsDataController     _projectsDataController;
+    private readonly IProjectTeamsDataController _projectTeamsDataController;
+    private readonly IToDosDataController        _toDosDataController;
+    private readonly ILogger<ProjectsService>    _logger;
+
+    public ProjectsService(
+        IProjectsDataController     projectsDataController,
+        IProjectTeamsDataController projectTeamsDataController,
+        IToDosDataController        toDosDataController,
+        ILogger<ProjectsService>    logger)
+    {
+        _projectsDataController     = projectsDataController;
+        _projectTeamsDataController = projectTeamsDataController;
+        _toDosDataController        = toDosDataController;
+        _logger                     = logger;
+    }
+
+    public async Task<List<ProjectResponseDto>> GetAllProjects()
+    {
+        var entities = await _projectsDataController.GetAllProjects();
+        return entities.Select(e => MapToDto(e.ToProject(), null)).ToList();
+    }
+
+    public async Task<ProjectResponseDto?> GetProjectById(Guid projectId)
+    {
+        var entity = await _projectsDataController.GetProjectById(projectId);
+        if (entity == null) return null;
+
+        var teamEntities = await _projectTeamsDataController.GetTeamsByProjectId(projectId);
+        var teams = teamEntities.Select(t => t.ToProjectTeam()).ToList();
+        return MapToDto(entity.ToProject(), teams);
+    }
+
+    public async Task<List<ProjectResponseDto>> GetProjectsByUserId(Guid userId)
+    {
+        var entities = await _projectsDataController.GetProjectsByUserId(userId);
+        return entities.Select(e => MapToDto(e.ToProject(), null)).ToList();
+    }
+
+    public async Task<bool> CreateProject(CreateProjectRequestDto request, Guid createdByUserId)
+    {
+        var entity = new ProjectEntity
+        {
+            Id          = request.Id,
+            Name        = request.Name,
+            Description = request.Description,
+            CreatedAt   = DateTime.UtcNow,
+            CreatedBy   = createdByUserId
+        };
+        return await _projectsDataController.CreateProject(entity);
+    }
+
+    public async Task<bool> UpdateProject(UpdateProjectRequestDto request)
+    {
+        var entity = new ProjectEntity
+        {
+            Id          = request.Id,
+            Name        = request.Name,
+            Description = request.Description
+        };
+        return await _projectsDataController.UpdateProject(entity);
+    }
+
+    public async Task<bool> DeleteProject(Guid projectId)
+        => await _projectsDataController.DeleteProject(projectId);
+
+    public async Task<bool> AddTeam(ProjectTeamUpsertRequestDto request)
+    {
+        var existing = await _projectTeamsDataController.GetByProjectIdAndTeamId(request.ProjectId, request.TeamId);
+        if (existing != null) return false;
+
+        var entity = new ProjectTeamEntity
+        {
+            Id        = request.Id,
+            ProjectId = request.ProjectId,
+            TeamId    = request.TeamId
+        };
+        return await _projectTeamsDataController.AddTeam(entity);
+    }
+
+    public async Task<bool> RemoveTeam(Guid projectId, Guid teamId)
+        => await _projectTeamsDataController.RemoveTeam(projectId, teamId);
+
+    public async Task<ProjectTeam?> GetProjectTeam(Guid projectId, Guid teamId)
+    {
+        var entity = await _projectTeamsDataController.GetByProjectIdAndTeamId(projectId, teamId);
+        return entity?.ToProjectTeam();
+    }
+
+    public async Task<List<ToDo>> GetToDosByProjectId(Guid projectId)
+    {
+        var entities = await _toDosDataController.GetToDosByProjectId(projectId);
+        return entities.Select(e => e.ToToDo()).ToList();
+    }
+
+    public async Task<bool> UserHasAccessToProject(Guid projectId, Guid userId)
+    {
+        var project = await _projectsDataController.GetProjectById(projectId);
+        if (project == null) return false;
+        if (project.CreatedBy == userId) return true;
+
+        var accessible = await _projectsDataController.GetProjectsByUserId(userId);
+        return accessible.Any(p => p.Id == projectId);
+    }
+
+    private static ProjectResponseDto MapToDto(Project project, List<ProjectTeam>? teams) => new()
+    {
+        Id          = project.Id,
+        Name        = project.Name,
+        Description = project.Description,
+        CreatedAt   = project.CreatedAt,
+        CreatedBy   = project.CreatedBy,
+        TeamCount   = project.TeamCount,
+        Teams       = teams
+    };
+}

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IProjectsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IProjectsService.cs
@@ -1,0 +1,19 @@
+using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.WebApi.Services.Interfaces;
+
+public interface IProjectsService
+{
+    Task<List<ProjectResponseDto>> GetAllProjects();
+    Task<ProjectResponseDto?>      GetProjectById(Guid projectId);
+    Task<List<ProjectResponseDto>> GetProjectsByUserId(Guid userId);
+    Task<bool>                     CreateProject(CreateProjectRequestDto request, Guid createdByUserId);
+    Task<bool>                     UpdateProject(UpdateProjectRequestDto request);
+    Task<bool>                     DeleteProject(Guid projectId);
+    Task<bool>                     AddTeam(ProjectTeamUpsertRequestDto request);
+    Task<bool>                     RemoveTeam(Guid projectId, Guid teamId);
+    Task<ProjectTeam?>             GetProjectTeam(Guid projectId, Guid teamId);
+    Task<List<ToDo>>               GetToDosByProjectId(Guid projectId);
+    Task<bool>                     UserHasAccessToProject(Guid projectId, Guid userId);
+}


### PR DESCRIPTION
Database:
- New Projects table (Id, Name, Description, CreatedAt, CreatedBy FK→Users)
- New ProjectTeams table (Id, ProjectId FK→Projects, TeamId FK→Teams)
  with UNIQUE constraint on (ProjectId, TeamId)
- ToDos table: added nullable ProjectId FK→Projects column
- 6 new Projects stored procedures (GetAll/GetById include TeamCount via COUNT JOIN;
  GetByUserId joins through ProjectTeams→TeamMembers; DeleteById cascades
  ProjectTeams nullification and ToDos.ProjectId)
- 4 new ProjectTeams stored procedures
- New sp_ToDos_GetByProjectId
- Updated all existing ToDos SPs to include ProjectId column in SELECT/INSERT/UPDATE

Shared:
- Project and ProjectTeam models
- CreateProjectRequestDto, UpdateProjectRequestDto, ProjectTeamUpsertRequestDto,
  ProjectResponseDto (Teams list null on list views, populated on GetById)
- ToDo model and ToDoUpsertRequestDto extended with nullable ProjectId

WebApi:
- ProjectEntity, ProjectTeamEntity with ToProject/ToProjectTeam conversion
- ToDoEntity extended with ProjectId
- IProjectsDataController + ProjectsDataController
- IProjectTeamsDataController + ProjectTeamsDataController
- IToDosDataController + ToDosDataController extended with GetToDosByProjectId
- IProjectsService + ProjectsService with access control logic:
  owner (CreatedBy) always has access; team-member access via SP join through
  ProjectTeams→TeamMembers; duplicate team-link guard on AddTeam
- ProjectsController at api/Projects with 9 endpoints:
  Admin-only: GetAll, Delete
  Owner or Admin: Update, AddTeam, RemoveTeam
  Accessible user or Admin: GetById, GetToDosByProjectId
  Any authenticated: GetMyProjects, Create
- Fixed ToDosController Create/Update to pass TeamId and ProjectId from DTO
- DI registrations for all new services in Program.cs

https://claude.ai/code/session_01FrnhXwkP9qtKmSF9J9gYjU