### PR TITLE
feat: move all validation and authorization to service layer

### DIFF
--- a/ToDoTimeManager.WebApi/Controllers/AuthController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/AuthController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Services.Interfaces;
@@ -10,47 +10,24 @@ namespace ToDoTimeManager.WebApi.Controllers;
 [Route("api/[controller]")]
 public class AuthController : ControllerBase
 {
-    private readonly ILogger<AuthController> _logger;
     private readonly IAuthService _authService;
-    private readonly IUsersService _usersService;
 
-    public AuthController(ILogger<AuthController> logger, IAuthService authService, IUsersService usersService)
+    public AuthController(IAuthService authService)
     {
-        _logger = logger;
         _authService = authService;
-        _usersService = usersService;
     }
 
     [HttpPost("Login")]
     public async Task<IActionResult> Login(LoginUser? loginUser)
     {
-        if (loginUser is null)
-            return Unauthorized("Login data is null");
-        if (string.IsNullOrWhiteSpace(loginUser.Password) || string.IsNullOrWhiteSpace(loginUser.LoginParameter))
-            return Unauthorized("Login data is invalid");
-
-        var user = await _usersService.GetUserByLoginParameter(loginUser.LoginParameter);
-        if (user is null)
-            return Unauthorized("User was not found");
-
-        var tokenModel = _authService.AuthenticateUser(loginUser, user);
-        if (tokenModel is null)
-            return Unauthorized("Invalid username or password");
-        return Ok(tokenModel);
+        var tokenModel = await _authService.Login(loginUser!);
+        return tokenModel != null ? Ok(tokenModel) : StatusCode(500);
     }
 
     [HttpPost("RefreshToken")]
     public IActionResult RefreshToken(TokenModel? tokenModel)
     {
-        if (tokenModel is null || string.IsNullOrWhiteSpace(tokenModel.RefreshToken))
-            return Unauthorized("Token data is null or invalid");
-
-        if (tokenModel.RefreshTokenExpiresAt < DateTime.UtcNow)
-            return Unauthorized("Refresh token has expired");
-
-        var newTokenModel = _authService.RefreshAuthToken(tokenModel);
-        if (newTokenModel is null)
-            return Unauthorized("Could not refresh token");
-        return Ok(newTokenModel);
+        var newTokenModel = _authService.RefreshAuthToken(tokenModel!);
+        return newTokenModel != null ? Ok(newTokenModel) : StatusCode(500);
     }
 }

--- a/ToDoTimeManager.WebApi/Controllers/ProjectsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/ProjectsController.cs
@@ -12,18 +12,14 @@ namespace ToDoTimeManager.WebApi.Controllers;
 public class ProjectsController : ControllerBase
 {
     private readonly IProjectsService _projectsService;
-    private readonly ILogger<ProjectsController> _logger;
 
-    public ProjectsController(IProjectsService projectsService, ILogger<ProjectsController> logger)
+    public ProjectsController(IProjectsService projectsService)
     {
         _projectsService = projectsService;
-        _logger = logger;
     }
 
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
     private bool IsAdmin() => User.IsInRole("Admin");
-
-    // ── Admin only ──────────────────────────────────────────────────────────
 
     [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
@@ -37,87 +33,44 @@ public class ProjectsController : ControllerBase
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteProject(Guid id)
     {
-        if (id == Guid.Empty) return BadRequest("Invalid project ID");
         var result = await _projectsService.DeleteProject(id);
-        return result ? Ok(result) : BadRequest("Project could not be deleted");
+        return result ? Ok(result) : StatusCode(500);
     }
-
-    // ── Admin or project-accessible user (read) ─────────────────────────────
 
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetProjectById(Guid id)
     {
-        if (id == Guid.Empty) return BadRequest("Invalid project ID");
-
-        var project = await _projectsService.GetProjectById(id);
-        if (project == null) return NotFound("Project was not found");
-
-        if (!IsAdmin() && !await _projectsService.UserHasAccessToProject(id, GetCurrentUserId()))
-            return Forbid();
-
-        return Ok(project);
+        var project = await _projectsService.GetProjectById(id, GetCurrentUserId(), IsAdmin());
+        return project != null ? Ok(project) : StatusCode(500);
     }
 
     [HttpGet("GetToDosByProjectId/{projectId}")]
     public async Task<IActionResult> GetToDosByProjectId(Guid projectId)
     {
-        if (projectId == Guid.Empty) return BadRequest("Invalid project ID");
-
-        if (!IsAdmin() && !await _projectsService.UserHasAccessToProject(projectId, GetCurrentUserId()))
-            return Forbid();
-
-        var todos = await _projectsService.GetToDosByProjectId(projectId);
+        var todos = await _projectsService.GetToDosByProjectId(projectId, GetCurrentUserId(), IsAdmin());
         return Ok(todos);
     }
-
-    // ── Admin or project owner (writes) ────────────────────────────────────
 
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateProject([FromBody] UpdateProjectRequestDto request)
     {
-        if (!IsAdmin())
-        {
-            var project = await _projectsService.GetProjectById(request.Id);
-            if (project == null) return NotFound("Project was not found");
-            if (project.CreatedBy != GetCurrentUserId()) return Forbid();
-        }
-
-        var result = await _projectsService.UpdateProject(request);
-        return result ? Ok(result) : BadRequest("Project could not be updated");
+        var result = await _projectsService.UpdateProject(request, GetCurrentUserId(), IsAdmin());
+        return result ? Ok(result) : StatusCode(500);
     }
 
     [HttpPost("AddTeam")]
     public async Task<IActionResult> AddTeam([FromBody] ProjectTeamUpsertRequestDto request)
     {
-        if (!IsAdmin())
-        {
-            var project = await _projectsService.GetProjectById(request.ProjectId);
-            if (project == null) return NotFound("Project was not found");
-            if (project.CreatedBy != GetCurrentUserId()) return Forbid();
-        }
-
-        var result = await _projectsService.AddTeam(request);
-        return result ? Ok(result) : BadRequest("Team could not be added (already linked or invalid data)");
+        var result = await _projectsService.AddTeam(request, GetCurrentUserId(), IsAdmin());
+        return result ? Ok(result) : StatusCode(500);
     }
 
     [HttpDelete("RemoveTeam/{projectId}/{teamId}")]
     public async Task<IActionResult> RemoveTeam(Guid projectId, Guid teamId)
     {
-        if (projectId == Guid.Empty || teamId == Guid.Empty)
-            return BadRequest("Invalid project or team ID");
-
-        if (!IsAdmin())
-        {
-            var project = await _projectsService.GetProjectById(projectId);
-            if (project == null) return NotFound("Project was not found");
-            if (project.CreatedBy != GetCurrentUserId()) return Forbid();
-        }
-
-        var result = await _projectsService.RemoveTeam(projectId, teamId);
-        return result ? Ok(result) : BadRequest("Team could not be removed");
+        var result = await _projectsService.RemoveTeam(projectId, teamId, GetCurrentUserId(), IsAdmin());
+        return result ? Ok(result) : StatusCode(500);
     }
-
-    // ── Any authenticated user ──────────────────────────────────────────────
 
     [HttpGet("GetMyProjects")]
     public async Task<IActionResult> GetMyProjects()
@@ -130,6 +83,6 @@ public class ProjectsController : ControllerBase
     public async Task<IActionResult> CreateProject([FromBody] CreateProjectRequestDto request)
     {
         var result = await _projectsService.CreateProject(request, GetCurrentUserId());
-        return result ? Ok(result) : BadRequest("Project could not be created");
+        return result ? Ok(result) : StatusCode(500);
     }
 }

--- a/ToDoTimeManager.WebApi/Controllers/StatisticController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/StatisticController.cs
@@ -4,45 +4,34 @@ using System.Security.Claims;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
-namespace ToDoTimeManager.WebApi.Controllers
+namespace ToDoTimeManager.WebApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class StatisticController : ControllerBase
 {
-    [ApiController]
-    [Route("api/[controller]")]
-    [Authorize]
-    public class StatisticController : ControllerBase
+    private readonly IStatisticService _statisticService;
+
+    public StatisticController(IStatisticService statisticService)
     {
-        private readonly ILogger<StatisticController> _logger;
-        private readonly IStatisticService _statisticService;
+        _statisticService = statisticService;
+    }
 
-        public StatisticController(ILogger<StatisticController> logger, IStatisticService statisticService)
-        {
-            _logger = logger;
-            _statisticService = statisticService;
-        }
+    private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+    private bool IsAdmin() => User.IsInRole("Admin");
 
-        private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
-        private bool IsAdmin() => User.IsInRole("Admin");
+    [HttpGet("GetToDoCountStatisticsOfAllTimeByUserId/{userId}")]
+    public async Task<IActionResult> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId)
+    {
+        var statistics = await _statisticService.GetToDoCountStatisticsOfAllTimeByUserId(userId, GetCurrentUserId(), IsAdmin());
+        return Ok(statistics);
+    }
 
-        [HttpGet("GetToDoCountStatisticsOfAllTimeByUserId/{userId}")]
-        public async Task<IActionResult> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId)
-        {
-            if (userId == Guid.Empty)
-                return BadRequest("Invalid user ID");
-            if (userId != GetCurrentUserId() && !IsAdmin())
-                return Forbid();
-            var statistics = await _statisticService.GetToDoCountStatisticsOfAllTimeByUserId(userId);
-            return Ok(statistics);
-        }
-
-        [HttpPost("GetMainPageStatistic")]
-        public async Task<IActionResult> GetMainPageStatistic([FromBody] MainPageStatisticRequest filter)
-        {
-            if (filter.UserId == Guid.Empty)
-                return BadRequest("Invalid user ID");
-            if (filter.UserId != GetCurrentUserId() && !IsAdmin())
-                return Forbid();
-            var statistic = await _statisticService.GetMainPageStatistic(filter);
-            return Ok(statistic);
-        }
+    [HttpPost("GetMainPageStatistic")]
+    public async Task<IActionResult> GetMainPageStatistic([FromBody] MainPageStatisticRequest filter)
+    {
+        var statistic = await _statisticService.GetMainPageStatistic(filter, GetCurrentUserId(), IsAdmin());
+        return statistic != null ? Ok(statistic) : StatusCode(500);
     }
 }

--- a/ToDoTimeManager.WebApi/Controllers/TeamsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/TeamsController.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 using ToDoTimeManager.Shared.DTOs;
-using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
@@ -13,18 +12,14 @@ namespace ToDoTimeManager.WebApi.Controllers;
 public class TeamsController : ControllerBase
 {
     private readonly ITeamsService _teamsService;
-    private readonly ILogger<TeamsController> _logger;
 
-    public TeamsController(ITeamsService teamsService, ILogger<TeamsController> logger)
+    public TeamsController(ITeamsService teamsService)
     {
         _teamsService = teamsService;
-        _logger = logger;
     }
 
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
     private bool IsAdmin() => User.IsInRole("Admin");
-
-    // ── Admin only ──────────────────────────────────────────────────────────
 
     [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
@@ -38,90 +33,44 @@ public class TeamsController : ControllerBase
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteTeam(Guid id)
     {
-        if (id == Guid.Empty) return BadRequest("Invalid team ID");
         var result = await _teamsService.DeleteTeam(id);
-        return result ? Ok(result) : BadRequest("Team could not be deleted");
+        return result ? Ok(result) : StatusCode(500);
     }
-
-    // ── Admin or team member ────────────────────────────────────────────────
 
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetTeamById(Guid id)
     {
-        if (id == Guid.Empty) return BadRequest("Invalid team ID");
-
-        var team = await _teamsService.GetTeamById(id);
-        if (team == null) return NotFound("Team was not found");
-
-        if (!IsAdmin())
-        {
-            var membership = await _teamsService.GetMembership(id, GetCurrentUserId());
-            if (membership == null) return Forbid();
-        }
-
-        return Ok(team);
+        var team = await _teamsService.GetTeamById(id, GetCurrentUserId(), IsAdmin());
+        return team != null ? Ok(team) : StatusCode(500);
     }
 
     [HttpGet("GetToDosByTeamId/{teamId}")]
     public async Task<IActionResult> GetToDosByTeamId(Guid teamId)
     {
-        if (teamId == Guid.Empty) return BadRequest("Invalid team ID");
-
-        if (!IsAdmin())
-        {
-            var membership = await _teamsService.GetMembership(teamId, GetCurrentUserId());
-            if (membership == null) return Forbid();
-        }
-
-        var todos = await _teamsService.GetToDosByTeamId(teamId);
+        var todos = await _teamsService.GetToDosByTeamId(teamId, GetCurrentUserId(), IsAdmin());
         return Ok(todos);
     }
-
-    // ── Admin or team owner ─────────────────────────────────────────────────
 
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateTeam([FromBody] UpdateTeamRequestDto request)
     {
-        if (!IsAdmin())
-        {
-            var membership = await _teamsService.GetMembership(request.Id, GetCurrentUserId());
-            if (membership == null || membership.Role != TeamMemberRole.Owner) return Forbid();
-        }
-
-        var result = await _teamsService.UpdateTeam(request);
-        return result ? Ok(result) : BadRequest("Team could not be updated");
+        var result = await _teamsService.UpdateTeam(request, GetCurrentUserId(), IsAdmin());
+        return result ? Ok(result) : StatusCode(500);
     }
 
     [HttpPost("AddMember")]
     public async Task<IActionResult> AddMember([FromBody] TeamMemberUpsertRequestDto request)
     {
-        if (!IsAdmin())
-        {
-            var membership = await _teamsService.GetMembership(request.TeamId, GetCurrentUserId());
-            if (membership == null || membership.Role != TeamMemberRole.Owner) return Forbid();
-        }
-
-        var result = await _teamsService.AddMember(request);
-        return result ? Ok(result) : BadRequest("Member could not be added (already exists or invalid data)");
+        var result = await _teamsService.AddMember(request, GetCurrentUserId(), IsAdmin());
+        return result ? Ok(result) : StatusCode(500);
     }
 
     [HttpDelete("RemoveMember/{teamId}/{userId}")]
     public async Task<IActionResult> RemoveMember(Guid teamId, Guid userId)
     {
-        if (teamId == Guid.Empty || userId == Guid.Empty)
-            return BadRequest("Invalid team or user ID");
-
-        if (!IsAdmin())
-        {
-            var membership = await _teamsService.GetMembership(teamId, GetCurrentUserId());
-            if (membership == null || membership.Role != TeamMemberRole.Owner) return Forbid();
-        }
-
-        var result = await _teamsService.RemoveMember(teamId, userId);
-        return result ? Ok(result) : BadRequest("Member could not be removed (last owner or not found)");
+        var result = await _teamsService.RemoveMember(teamId, userId, GetCurrentUserId(), IsAdmin());
+        return result ? Ok(result) : StatusCode(500);
     }
-
-    // ── Any authenticated user ──────────────────────────────────────────────
 
     [HttpGet("GetMyTeams")]
     public async Task<IActionResult> GetMyTeams()
@@ -134,6 +83,6 @@ public class TeamsController : ControllerBase
     public async Task<IActionResult> CreateTeam([FromBody] CreateTeamRequestDto request)
     {
         var result = await _teamsService.CreateTeam(request, GetCurrentUserId());
-        return result ? Ok(result) : BadRequest("Team could not be created");
+        return result ? Ok(result) : StatusCode(500);
     }
 }

--- a/ToDoTimeManager.WebApi/Controllers/TimeLogsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/TimeLogsController.cs
@@ -12,12 +12,10 @@ namespace ToDoTimeManager.WebApi.Controllers;
 [Route("api/[controller]")]
 public class TimeLogsController : ControllerBase
 {
-    private readonly ILogger<TimeLogsController> _logger;
     private readonly ITimeLogsService _timeLogsService;
 
-    public TimeLogsController(ILogger<TimeLogsController> logger, ITimeLogsService timeLogsService)
+    public TimeLogsController(ITimeLogsService timeLogsService)
     {
-        _logger = logger;
         _timeLogsService = timeLogsService;
     }
 
@@ -35,20 +33,13 @@ public class TimeLogsController : ControllerBase
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetTimeLogById(Guid id)
     {
-        if (id == Guid.Empty)
-            return BadRequest("Invalid time log ID");
-        var timeLog = await _timeLogsService.GetTimeLogById(id);
-        if (timeLog == null) return NotFound("Time log was not found");
-        if (timeLog.UserId != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-        return Ok(timeLog);
+        var timeLog = await _timeLogsService.GetTimeLogById(id, GetCurrentUserId(), IsAdmin());
+        return timeLog != null ? Ok(timeLog) : StatusCode(500);
     }
 
     [HttpGet("GetByToDoId/{toDoId}")]
     public async Task<IActionResult> GetTimeLogsByToDoId(Guid toDoId)
     {
-        if (toDoId == Guid.Empty)
-            return BadRequest("Invalid to-do ID");
         var timeLogs = await _timeLogsService.GetTimeLogsByToDoId(toDoId);
         return Ok(timeLogs);
     }
@@ -56,24 +47,14 @@ public class TimeLogsController : ControllerBase
     [HttpGet("GetByUserId/{userId}")]
     public async Task<IActionResult> GetTimeLogsByUserId(Guid userId)
     {
-        if (userId == Guid.Empty)
-            return BadRequest("Invalid user ID");
-        if (userId != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-        var timeLogs = await _timeLogsService.GetTimeLogsByUserId(userId);
+        var timeLogs = await _timeLogsService.GetTimeLogsByUserId(userId, GetCurrentUserId(), IsAdmin());
         return Ok(timeLogs);
     }
 
     [HttpGet("GetByUserIdAndToDoId/{userId}/{toDoId}")]
     public async Task<IActionResult> GetTimeLogsByUserIdAndToDoId(Guid userId, Guid toDoId)
     {
-        if (userId == Guid.Empty)
-            return BadRequest("Invalid user ID");
-        if (toDoId == Guid.Empty)
-            return BadRequest("Invalid to-do ID");
-        if (userId != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-        var timeLogs = await _timeLogsService.GetTimeLogsByUserIdAndToDoId(toDoId, userId);
+        var timeLogs = await _timeLogsService.GetTimeLogsByUserIdAndToDoId(toDoId, userId, GetCurrentUserId(), IsAdmin());
         return Ok(timeLogs);
     }
 
@@ -82,50 +63,39 @@ public class TimeLogsController : ControllerBase
     {
         var timeLog = new TimeLog
         {
-            Id = request.Id,
-            ToDoId = request.ToDoId,
-            UserId = request.UserId,
-            HoursSpent = request.HoursSpent!.Value,
-            LogDate = request.LogDate!.Value,
+            Id             = request.Id,
+            ToDoId         = request.ToDoId,
+            UserId         = request.UserId,
+            HoursSpent     = request.HoursSpent!.Value,
+            LogDate        = request.LogDate!.Value,
             LogDescription = request.LogDescription
         };
 
-        var newTimeLog = await _timeLogsService.CreateTimeLog(timeLog);
-        return newTimeLog ? Ok(newTimeLog) : BadRequest("Time log could not be created");
+        var created = await _timeLogsService.CreateTimeLog(timeLog);
+        return created ? Ok(created) : StatusCode(500);
     }
 
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateTimeLog([FromBody] TimeLogUpsertRequestDto request)
     {
-        var existing = await _timeLogsService.GetTimeLogById(request.Id);
-        if (existing == null) return NotFound("Time log was not found");
-        if (existing.UserId != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-
         var timeLog = new TimeLog
         {
-            Id = request.Id,
-            ToDoId = request.ToDoId,
-            UserId = request.UserId,
-            HoursSpent = request.HoursSpent!.Value,
-            LogDate = request.LogDate!.Value,
+            Id             = request.Id,
+            ToDoId         = request.ToDoId,
+            UserId         = request.UserId,
+            HoursSpent     = request.HoursSpent!.Value,
+            LogDate        = request.LogDate!.Value,
             LogDescription = request.LogDescription
         };
 
-        var updateTimeLog = await _timeLogsService.UpdateTimeLog(timeLog);
-        return updateTimeLog ? Ok(updateTimeLog) : BadRequest("Time log could not be updated");
+        var updated = await _timeLogsService.UpdateTimeLog(timeLog, GetCurrentUserId(), IsAdmin());
+        return updated ? Ok(updated) : StatusCode(500);
     }
 
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteTimeLog(Guid id)
     {
-        if (id == Guid.Empty)
-            return BadRequest("Invalid time log ID");
-        var existing = await _timeLogsService.GetTimeLogById(id);
-        if (existing == null) return NotFound("Time log was not found");
-        if (existing.UserId != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-        var deleted = await _timeLogsService.DeleteTimeLog(id);
-        return deleted ? Ok(deleted) : BadRequest("Time log could not be deleted");
+        var deleted = await _timeLogsService.DeleteTimeLog(id, GetCurrentUserId(), IsAdmin());
+        return deleted ? Ok(deleted) : StatusCode(500);
     }
 }

--- a/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
@@ -12,12 +12,10 @@ namespace ToDoTimeManager.WebApi.Controllers;
 [Route("api/[controller]")]
 public class ToDosController : ControllerBase
 {
-    private readonly ILogger<ToDosController> _logger;
     private readonly IToDosService _toDosService;
 
-    public ToDosController(ILogger<ToDosController> logger, IToDosService toDosService)
+    public ToDosController(IToDosService toDosService)
     {
-        _logger = logger;
         _toDosService = toDosService;
     }
 
@@ -35,23 +33,14 @@ public class ToDosController : ControllerBase
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetToDoById(Guid id)
     {
-        if (id == Guid.Empty)
-            return BadRequest("Invalid to-do ID");
-        var toDo = await _toDosService.GetToDoById(id);
-        if (toDo == null) return NotFound("To-do was not found");
-        if (toDo.AssignedTo != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-        return Ok(toDo);
+        var toDo = await _toDosService.GetToDoById(id, GetCurrentUserId(), IsAdmin());
+        return toDo != null ? Ok(toDo) : StatusCode(500);
     }
 
     [HttpGet("GetByUserId/{userId}")]
     public async Task<IActionResult> GetToDosByUserId(Guid userId)
     {
-        if (userId == Guid.Empty)
-            return BadRequest("Invalid user ID");
-        if (userId != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-        var toDos = await _toDosService.GetToDosByUserId(userId);
+        var toDos = await _toDosService.GetToDosByUserId(userId, GetCurrentUserId(), IsAdmin());
         return Ok(toDos);
     }
 
@@ -72,18 +61,13 @@ public class ToDosController : ControllerBase
             ProjectId   = request.ProjectId
         };
 
-        var newToDo = await _toDosService.CreateToDo(toDo);
-        return newToDo ? Ok(newToDo) : BadRequest("To-do could not be created");
+        var created = await _toDosService.CreateToDo(toDo);
+        return created ? Ok(created) : StatusCode(500);
     }
 
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateToDo([FromBody] ToDoUpsertRequestDto request)
     {
-        var existing = await _toDosService.GetToDoById(request.Id);
-        if (existing == null) return NotFound("To-do was not found");
-        if (existing.AssignedTo != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-
         var toDo = new ToDo
         {
             Id          = request.Id,
@@ -98,20 +82,14 @@ public class ToDosController : ControllerBase
             ProjectId   = request.ProjectId
         };
 
-        var updatedToDo = await _toDosService.UpdateToDo(toDo);
-        return updatedToDo ? Ok(updatedToDo) : BadRequest("To-do could not be updated");
+        var updated = await _toDosService.UpdateToDo(toDo, GetCurrentUserId(), IsAdmin());
+        return updated ? Ok(updated) : StatusCode(500);
     }
 
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteToDo(Guid id)
     {
-        if (id == Guid.Empty)
-            return BadRequest("Invalid to-do ID");
-        var existing = await _toDosService.GetToDoById(id);
-        if (existing == null) return NotFound("To-do was not found");
-        if (existing.AssignedTo != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-        var deletedToDo = await _toDosService.DeleteToDo(id);
-        return deletedToDo ? Ok(deletedToDo) : BadRequest("To-do could not be deleted");
+        var deleted = await _toDosService.DeleteToDo(id, GetCurrentUserId(), IsAdmin());
+        return deleted ? Ok(deleted) : StatusCode(500);
     }
 }

--- a/ToDoTimeManager.WebApi/Controllers/UsersController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/UsersController.cs
@@ -1,12 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Linq;
 using System.Security.Claims;
 using ToDoTimeManager.Shared.DTOs;
 using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Services.Interfaces;
-using ToDoTimeManager.WebApi.Utils.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
@@ -14,15 +12,11 @@ namespace ToDoTimeManager.WebApi.Controllers;
 [Route("api/[controller]")]
 public class UsersController : ControllerBase
 {
-    private readonly ILogger<UsersController> _logger;
     private readonly IUsersService _usersService;
-    private readonly IPasswordHelperService _passwordHelperService;
 
-    public UsersController(ILogger<UsersController> logger, IUsersService usersService, IPasswordHelperService passwordHelperService)
+    public UsersController(IUsersService usersService)
     {
-        _logger = logger;
         _usersService = usersService;
-        _passwordHelperService = passwordHelperService;
     }
 
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
@@ -40,121 +34,71 @@ public class UsersController : ControllerBase
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetUserById(Guid id)
     {
-        if (id == Guid.Empty)
-            return BadRequest("Invalid user ID");
-        if (id != GetCurrentUserId() && !IsAdmin())
-            return Forbid();
-        var user = await _usersService.GetUserById(id);
-        return user == null ? NotFound("User was not found") : Ok(ToUserResponseDto(user));
+        var user = await _usersService.GetUserById(id, GetCurrentUserId(), IsAdmin());
+        return user != null ? Ok(ToUserResponseDto(user)) : StatusCode(500);
     }
 
     [Authorize(Roles = "Admin")]
     [HttpGet("GetByUsername/{userName}")]
     public async Task<IActionResult> GetUserByUsername(string userName)
     {
-        if (string.IsNullOrWhiteSpace(userName))
-            return BadRequest("Invalid username");
         var user = await _usersService.GetUserByUsername(userName);
-        return user is null ? NotFound("User was not found") : Ok(ToUserResponseDto(user));
+        return user != null ? Ok(ToUserResponseDto(user)) : StatusCode(500);
     }
 
     [Authorize(Roles = "Admin")]
     [HttpGet("GetByEmail/{email}")]
     public async Task<IActionResult> GetUserByEmail(string email)
     {
-        if (string.IsNullOrWhiteSpace(email))
-            return BadRequest("Invalid email");
         var user = await _usersService.GetUserByEmail(email);
-        return user is null ? NotFound("User was not found") : Ok(ToUserResponseDto(user));
+        return user != null ? Ok(ToUserResponseDto(user)) : StatusCode(500);
     }
 
     [Authorize(Roles = "Admin")]
     [HttpGet("GetByLoginParameter/{loginParameter}")]
     public async Task<IActionResult> GetUserByLoginParameter(string loginParameter)
     {
-        if (string.IsNullOrWhiteSpace(loginParameter))
-            return BadRequest("Invalid login parameter");
         var user = await _usersService.GetUserByLoginParameter(loginParameter);
-        return user is null ? NotFound("User was not found") : Ok(ToUserResponseDto(user));
+        return user != null ? Ok(ToUserResponseDto(user)) : StatusCode(500);
     }
 
     [AllowAnonymous]
     [HttpPost("Create")]
     public async Task<IActionResult> CreateUser([FromBody] CreateUserRequestDto request)
     {
-        var user = new User
-        {
-            Id = request.Id,
-            UserName = request.UserName,
-            Email = request.Email,
-            Password = request.Password,
-            UserRole = UserRole.User  // role is always set server-side; client cannot escalate to Admin
-        };
-
-        var created = await _usersService.CreateUser(user);
-        return created ? Ok(created) : BadRequest("User could not be created");
+        var created = await _usersService.CreateUser(request);
+        return created ? Ok(created) : StatusCode(500);
     }
 
     [Authorize]
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateUser([FromBody] UpdateUserRequestDto request)
     {
-        if (request.Id != GetCurrentUserId())
-            return Forbid();
-
-        var existingUser = await _usersService.GetUserById(request.Id);
-        if (existingUser is null)
-            return NotFound("User was not found");
-
-        var passwordHash = !string.IsNullOrWhiteSpace(request.Password)
-            ? _passwordHelperService.HashPassword(request.Id.ToString(), request.Password)
-            : existingUser.Password;
-
-        if (string.IsNullOrWhiteSpace(passwordHash))
-            return BadRequest("User password is missing");
-
-        var updatedUser = new User
-        {
-            Id = request.Id,
-            UserName = request.UserName,
-            Email = request.Email,
-            UserRole = existingUser.UserRole,  // role is never changed via this endpoint
-            Password = passwordHash
-        };
-
-        var res = await _usersService.UpdateUser(updatedUser);
-        return res ? Ok(res) : BadRequest("User could not be updated");
+        var result = await _usersService.UpdateUser(request, GetCurrentUserId());
+        return result ? Ok(result) : StatusCode(500);
     }
 
     [Authorize(Roles = "Admin")]
     [HttpPut("ChangeRole/{id}")]
     public async Task<IActionResult> ChangeUserRole(Guid id, [FromBody] ChangeUserRoleRequestDto request)
     {
-        if (id == Guid.Empty)
-            return BadRequest("Invalid user ID");
         var changed = await _usersService.ChangeUserRole(id, request.NewRole);
-        return changed ? Ok(changed) : NotFound("User was not found");
+        return changed ? Ok(changed) : StatusCode(500);
     }
 
     [Authorize(Roles = "Admin")]
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteUser(Guid id)
     {
-        if (id == Guid.Empty)
-            return BadRequest("Invalid user ID");
-        var deletedUser = await _usersService.DeleteUser(id);
-        return deletedUser ? Ok(deletedUser) : BadRequest("User could not be deleted");
+        var deleted = await _usersService.DeleteUser(id);
+        return deleted ? Ok(deleted) : StatusCode(500);
     }
 
-
-    private static UserResponseDto ToUserResponseDto(User user)
+    private static UserResponseDto ToUserResponseDto(User user) => new()
     {
-        return new UserResponseDto
-        {
-            Id = user.Id,
-            UserName = user.UserName,
-            Email = user.Email,
-            UserRole = user.UserRole
-        };
-    }
+        Id       = user.Id,
+        UserName = user.UserName,
+        Email    = user.Email,
+        UserRole = user.UserRole
+    };
 }

--- a/ToDoTimeManager.WebApi/Exceptions/ConflictException.cs
+++ b/ToDoTimeManager.WebApi/Exceptions/ConflictException.cs
@@ -1,0 +1,6 @@
+namespace ToDoTimeManager.WebApi.Exceptions;
+
+public class ConflictException : ServiceException
+{
+    public ConflictException(string message) : base(409, message) { }
+}

--- a/ToDoTimeManager.WebApi/Exceptions/ForbiddenException.cs
+++ b/ToDoTimeManager.WebApi/Exceptions/ForbiddenException.cs
@@ -1,0 +1,6 @@
+namespace ToDoTimeManager.WebApi.Exceptions;
+
+public class ForbiddenException : ServiceException
+{
+    public ForbiddenException(string message = "Access denied") : base(403, message) { }
+}

--- a/ToDoTimeManager.WebApi/Exceptions/NotFoundException.cs
+++ b/ToDoTimeManager.WebApi/Exceptions/NotFoundException.cs
@@ -1,0 +1,6 @@
+namespace ToDoTimeManager.WebApi.Exceptions;
+
+public class NotFoundException : ServiceException
+{
+    public NotFoundException(string message) : base(404, message) { }
+}

--- a/ToDoTimeManager.WebApi/Exceptions/ServiceException.cs
+++ b/ToDoTimeManager.WebApi/Exceptions/ServiceException.cs
@@ -1,0 +1,11 @@
+namespace ToDoTimeManager.WebApi.Exceptions;
+
+public class ServiceException : Exception
+{
+    public int StatusCode { get; }
+
+    public ServiceException(int statusCode, string message) : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}

--- a/ToDoTimeManager.WebApi/Exceptions/ValidationException.cs
+++ b/ToDoTimeManager.WebApi/Exceptions/ValidationException.cs
@@ -1,0 +1,6 @@
+namespace ToDoTimeManager.WebApi.Exceptions;
+
+public class ValidationException : ServiceException
+{
+    public ValidationException(string message) : base(400, message) { }
+}

--- a/ToDoTimeManager.WebApi/Middleware/GlobalExceptionHandler.cs
+++ b/ToDoTimeManager.WebApi/Middleware/GlobalExceptionHandler.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using System.Diagnostics;
-using ToDoTimeManager.WebApi.AdditionalComponents;
+using ToDoTimeManager.WebApi.Exceptions;
 
 namespace ToDoTimeManager.WebApi.Middleware;
 
@@ -14,33 +14,42 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IM
             await next(context);
             stopwatch.Stop();
         }
-        catch (CustomException exception)
+        catch (ServiceException exception)
         {
             stopwatch.Stop();
-            logger.LogError(exception, $"Custom exception caught in middleware. Elapsed Time: {stopwatch.ElapsedMilliseconds} ms");
-            var problemDetails = CreateProblemDetails(StatusCodes.Status400BadRequest, "Client Error", exception.Message);
+            logger.LogWarning(exception, "Service exception caught. StatusCode: {StatusCode}. Elapsed: {Elapsed} ms",
+                exception.StatusCode, stopwatch.ElapsedMilliseconds);
 
-            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            var problemDetails = CreateProblemDetails(exception.StatusCode, GetTitle(exception.StatusCode), exception.Message);
+            context.Response.StatusCode = exception.StatusCode;
             await context.Response.WriteAsJsonAsync(problemDetails);
         }
         catch (Exception exception)
         {
             stopwatch.Stop();
-            logger.LogError(exception, $"An unhandled exception has occurred. Elapsed Time: {stopwatch.ElapsedMilliseconds} ms");
+            logger.LogError(exception, "An unhandled exception has occurred. Elapsed: {Elapsed} ms", stopwatch.ElapsedMilliseconds);
 
             var problemDetails = CreateProblemDetails(StatusCodes.Status500InternalServerError, "An unexpected error occurred");
-
             context.Response.StatusCode = StatusCodes.Status500InternalServerError;
             await context.Response.WriteAsJsonAsync(problemDetails);
         }
     }
+
+    private static string GetTitle(int statusCode) => statusCode switch
+    {
+        400 => "Validation Error",
+        403 => "Forbidden",
+        404 => "Not Found",
+        409 => "Conflict",
+        _   => "Error"
+    };
 
     private static ProblemDetails CreateProblemDetails(int status, string title, string? detail = null)
     {
         return new ProblemDetails
         {
             Status = status,
-            Title = title,
+            Title  = title,
             Detail = detail
         };
     }

--- a/ToDoTimeManager.WebApi/Services/Implementations/AuthService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/AuthService.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
-using ToDoTimeManager.Shared.Utils;
+using ToDoTimeManager.WebApi.Exceptions;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 using ToDoTimeManager.WebApi.Utils.Interfaces;
 
@@ -16,54 +17,50 @@ public class AuthService : IAuthService
     private readonly IPasswordHelperService _passwordHelperService;
     private readonly IJwtGeneratorService _jwtGeneratorService;
     private readonly IConfiguration _configuration;
+    private readonly IUsersDataController _usersDataController;
 
-    public AuthService(ILogger<AuthService> logger, IPasswordHelperService passwordHelperService, IJwtGeneratorService jwtGeneratorService, IConfiguration configuration)
+    public AuthService(
+        ILogger<AuthService> logger,
+        IPasswordHelperService passwordHelperService,
+        IJwtGeneratorService jwtGeneratorService,
+        IConfiguration configuration,
+        IUsersDataController usersDataController)
     {
         _logger = logger;
         _passwordHelperService = passwordHelperService;
         _jwtGeneratorService = jwtGeneratorService;
         _configuration = configuration;
+        _usersDataController = usersDataController;
     }
 
-    private (string? UserId, string? Role) ValidateAndReadToken(string token)
+    public async Task<TokenModel?> Login(LoginUser loginUser)
     {
-        var key = _configuration["JwtSettings:Key"] ?? string.Empty;
-        var issuer = _configuration["JwtSettings:Issuer"];
-        var audience = _configuration["JwtSettings:Audience"];
+        if (loginUser == null || string.IsNullOrWhiteSpace(loginUser.LoginParameter))
+            throw new ValidationException("Login data is invalid");
+        if (string.IsNullOrWhiteSpace(loginUser.Password))
+            throw new ValidationException("Password is required");
 
-        var validationParams = new TokenValidationParameters
-        {
-            ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key)),
-            ValidateIssuer = true,
-            ValidIssuer = issuer,
-            ValidateAudience = true,
-            ValidAudience = audience,
-            ValidateLifetime = false,  // allow expired tokens to be refreshed
-            ClockSkew = TimeSpan.Zero
-        };
-
-        var handler = new JwtSecurityTokenHandler();
-        var principal = handler.ValidateToken(token, validationParams, out _);
-        var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier);
-        var role = principal.FindFirstValue(ClaimTypes.Role);
-        return (userId, role);
-    }
-
-    public TokenModel? AuthenticateUser(LoginUser loginUser, User user)
-    {
         try
         {
-            if (!_passwordHelperService.VerifyPassword(user,
-                    _passwordHelperService.HashPassword(user.Id.ToString(), loginUser.Password!)))
-                return null;
+            var userEntity = await _usersDataController.GetUserByLoginParameter(loginUser.LoginParameter);
+            if (userEntity == null)
+                throw new ValidationException("Invalid username or password");
 
-            return new TokenModel()
+            var user = userEntity.ToUser();
+            var passwordHash = _passwordHelperService.HashPassword(user.Id.ToString(), loginUser.Password);
+            if (!_passwordHelperService.VerifyPassword(user, passwordHash))
+                throw new ValidationException("Invalid username or password");
+
+            return new TokenModel
             {
-                AccessToken = _jwtGeneratorService.GenerateAccessToken(user.Id.ToString(), user.UserRole),
-                RefreshToken = _jwtGeneratorService.GenerateRefreshToken(),
+                AccessToken          = _jwtGeneratorService.GenerateAccessToken(user.Id.ToString(), user.UserRole),
+                RefreshToken         = _jwtGeneratorService.GenerateRefreshToken(),
                 RefreshTokenExpiresAt = DateTime.UtcNow.AddDays(int.Parse(_configuration["JwtSettings:RefreshTokenLifetime"] ?? "7"))
             };
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -74,23 +71,57 @@ public class AuthService : IAuthService
 
     public TokenModel? RefreshAuthToken(TokenModel tokenModel)
     {
+        if (tokenModel == null || string.IsNullOrWhiteSpace(tokenModel.RefreshToken))
+            throw new ValidationException("Token data is null or invalid");
+        if (tokenModel.RefreshTokenExpiresAt < DateTime.UtcNow)
+            throw new ValidationException("Refresh token has expired");
+
         try
         {
             var (userId, userRole) = ValidateAndReadToken(tokenModel.AccessToken!);
             if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(userRole))
-                return null;
+                throw new ValidationException("Could not refresh token");
 
-            return new TokenModel()
+            return new TokenModel
             {
-                AccessToken = _jwtGeneratorService.GenerateAccessToken(userId, Enum.Parse<UserRole>(userRole)),
-                RefreshToken = tokenModel.RefreshToken,
+                AccessToken           = _jwtGeneratorService.GenerateAccessToken(userId, Enum.Parse<UserRole>(userRole)),
+                RefreshToken          = tokenModel.RefreshToken,
                 RefreshTokenExpiresAt = tokenModel.RefreshTokenExpiresAt
             };
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, ex.Message);
             return null;
         }
+    }
+
+    private (string? UserId, string? Role) ValidateAndReadToken(string token)
+    {
+        var key      = _configuration["JwtSettings:Key"] ?? string.Empty;
+        var issuer   = _configuration["JwtSettings:Issuer"];
+        var audience = _configuration["JwtSettings:Audience"];
+
+        var validationParams = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key)),
+            ValidateIssuer           = true,
+            ValidIssuer              = issuer,
+            ValidateAudience         = true,
+            ValidAudience            = audience,
+            ValidateLifetime         = false,  // allow expired tokens to be refreshed
+            ClockSkew                = TimeSpan.Zero
+        };
+
+        var handler   = new JwtSecurityTokenHandler();
+        var principal = handler.ValidateToken(token, validationParams, out _);
+        var userId    = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+        var role      = principal.FindFirstValue(ClaimTypes.Role);
+        return (userId, role);
     }
 }

--- a/ToDoTimeManager.WebApi/Services/Implementations/ProjectsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/ProjectsService.cs
@@ -1,6 +1,7 @@
 using ToDoTimeManager.Shared.DTOs;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Exceptions;
 using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
@@ -31,14 +32,33 @@ public class ProjectsService : IProjectsService
         return entities.Select(e => MapToDto(e.ToProject(), null)).ToList();
     }
 
-    public async Task<ProjectResponseDto?> GetProjectById(Guid projectId)
+    public async Task<ProjectResponseDto?> GetProjectById(Guid projectId, Guid currentUserId, bool isAdmin)
     {
-        var entity = await _projectsDataController.GetProjectById(projectId);
-        if (entity == null) return null;
+        if (projectId == Guid.Empty)
+            throw new ValidationException("Invalid project ID");
 
-        var teamEntities = await _projectTeamsDataController.GetTeamsByProjectId(projectId);
-        var teams = teamEntities.Select(t => t.ToProjectTeam()).ToList();
-        return MapToDto(entity.ToProject(), teams);
+        try
+        {
+            var entity = await _projectsDataController.GetProjectById(projectId);
+            if (entity == null)
+                throw new NotFoundException("Project was not found");
+
+            if (!isAdmin && !await UserHasAccess(projectId, currentUserId, entity.CreatedBy))
+                throw new ForbiddenException();
+
+            var teamEntities = await _projectTeamsDataController.GetTeamsByProjectId(projectId);
+            var teams = teamEntities.Select(t => t.ToProjectTeam()).ToList();
+            return MapToDto(entity.ToProject(), teams);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return null;
+        }
     }
 
     public async Task<List<ProjectResponseDto>> GetProjectsByUserId(Guid userId)
@@ -49,66 +69,189 @@ public class ProjectsService : IProjectsService
 
     public async Task<bool> CreateProject(CreateProjectRequestDto request, Guid createdByUserId)
     {
-        var entity = new ProjectEntity
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new ValidationException("Project name is required");
+
+        try
         {
-            Id          = request.Id,
-            Name        = request.Name,
-            Description = request.Description,
-            CreatedAt   = DateTime.UtcNow,
-            CreatedBy   = createdByUserId
-        };
-        return await _projectsDataController.CreateProject(entity);
+            var entity = new ProjectEntity
+            {
+                Id          = request.Id,
+                Name        = request.Name,
+                Description = request.Description,
+                CreatedAt   = DateTime.UtcNow,
+                CreatedBy   = createdByUserId
+            };
+            return await _projectsDataController.CreateProject(entity);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
     }
 
-    public async Task<bool> UpdateProject(UpdateProjectRequestDto request)
+    public async Task<bool> UpdateProject(UpdateProjectRequestDto request, Guid currentUserId, bool isAdmin)
     {
-        var entity = new ProjectEntity
+        if (request.Id == Guid.Empty)
+            throw new ValidationException("Invalid project ID");
+
+        try
         {
-            Id          = request.Id,
-            Name        = request.Name,
-            Description = request.Description
-        };
-        return await _projectsDataController.UpdateProject(entity);
+            if (!isAdmin)
+            {
+                var project = await _projectsDataController.GetProjectById(request.Id);
+                if (project == null)
+                    throw new NotFoundException("Project was not found");
+                if (project.CreatedBy != currentUserId)
+                    throw new ForbiddenException();
+            }
+
+            var entity = new ProjectEntity
+            {
+                Id          = request.Id,
+                Name        = request.Name,
+                Description = request.Description
+            };
+            return await _projectsDataController.UpdateProject(entity);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
     }
 
     public async Task<bool> DeleteProject(Guid projectId)
-        => await _projectsDataController.DeleteProject(projectId);
-
-    public async Task<bool> AddTeam(ProjectTeamUpsertRequestDto request)
     {
-        var existing = await _projectTeamsDataController.GetByProjectIdAndTeamId(request.ProjectId, request.TeamId);
-        if (existing != null) return false;
+        if (projectId == Guid.Empty)
+            throw new ValidationException("Invalid project ID");
 
-        var entity = new ProjectTeamEntity
+        try
         {
-            Id        = request.Id,
-            ProjectId = request.ProjectId,
-            TeamId    = request.TeamId
-        };
-        return await _projectTeamsDataController.AddTeam(entity);
+            return await _projectsDataController.DeleteProject(projectId);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
     }
 
-    public async Task<bool> RemoveTeam(Guid projectId, Guid teamId)
-        => await _projectTeamsDataController.RemoveTeam(projectId, teamId);
-
-    public async Task<ProjectTeam?> GetProjectTeam(Guid projectId, Guid teamId)
+    public async Task<bool> AddTeam(ProjectTeamUpsertRequestDto request, Guid currentUserId, bool isAdmin)
     {
-        var entity = await _projectTeamsDataController.GetByProjectIdAndTeamId(projectId, teamId);
-        return entity?.ToProjectTeam();
+        if (request.ProjectId == Guid.Empty)
+            throw new ValidationException("Invalid project ID");
+
+        try
+        {
+            if (!isAdmin)
+            {
+                var project = await _projectsDataController.GetProjectById(request.ProjectId);
+                if (project == null)
+                    throw new NotFoundException("Project was not found");
+                if (project.CreatedBy != currentUserId)
+                    throw new ForbiddenException();
+            }
+
+            var existing = await _projectTeamsDataController.GetByProjectIdAndTeamId(request.ProjectId, request.TeamId);
+            if (existing != null)
+                throw new ConflictException("Team is already linked to this project");
+
+            var entity = new ProjectTeamEntity
+            {
+                Id        = request.Id,
+                ProjectId = request.ProjectId,
+                TeamId    = request.TeamId
+            };
+            return await _projectTeamsDataController.AddTeam(entity);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
     }
 
-    public async Task<List<ToDo>> GetToDosByProjectId(Guid projectId)
+    public async Task<bool> RemoveTeam(Guid projectId, Guid teamId, Guid currentUserId, bool isAdmin)
     {
-        var entities = await _toDosDataController.GetToDosByProjectId(projectId);
-        return entities.Select(e => e.ToToDo()).ToList();
+        if (projectId == Guid.Empty || teamId == Guid.Empty)
+            throw new ValidationException("Invalid project or team ID");
+
+        try
+        {
+            if (!isAdmin)
+            {
+                var project = await _projectsDataController.GetProjectById(projectId);
+                if (project == null)
+                    throw new NotFoundException("Project was not found");
+                if (project.CreatedBy != currentUserId)
+                    throw new ForbiddenException();
+            }
+
+            return await _projectTeamsDataController.RemoveTeam(projectId, teamId);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
     }
 
-    public async Task<bool> UserHasAccessToProject(Guid projectId, Guid userId)
+    public async Task<List<ToDo>> GetToDosByProjectId(Guid projectId, Guid currentUserId, bool isAdmin)
     {
-        var project = await _projectsDataController.GetProjectById(projectId);
-        if (project == null) return false;
-        if (project.CreatedBy == userId) return true;
+        if (projectId == Guid.Empty)
+            throw new ValidationException("Invalid project ID");
 
+        try
+        {
+            if (!isAdmin)
+            {
+                var project = await _projectsDataController.GetProjectById(projectId);
+                if (project == null)
+                    throw new NotFoundException("Project was not found");
+
+                if (!await UserHasAccess(projectId, currentUserId, project.CreatedBy))
+                    throw new ForbiddenException();
+            }
+
+            var entities = await _toDosDataController.GetToDosByProjectId(projectId);
+            return entities.Select(e => e.ToToDo()).ToList();
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
+
+    private async Task<bool> UserHasAccess(Guid projectId, Guid userId, Guid createdBy)
+    {
+        if (createdBy == userId) return true;
         var accessible = await _projectsDataController.GetProjectsByUserId(userId);
         return accessible.Any(p => p.Id == projectId);
     }

--- a/ToDoTimeManager.WebApi/Services/Implementations/StatisticService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/StatisticService.cs
@@ -1,5 +1,6 @@
-﻿using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.WebApi.Exceptions;
 using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
@@ -9,14 +10,25 @@ public class StatisticService : IStatisticService
 {
     private readonly IToDosDataController _toDosDataController;
     private readonly ITimeLogsDataController _timeLogsDataController;
-    public StatisticService(IToDosDataController toDosDataController, ITimeLogsDataController timeLogsDataController)
+    private readonly ILogger<StatisticService> _logger;
+
+    public StatisticService(
+        IToDosDataController toDosDataController,
+        ITimeLogsDataController timeLogsDataController,
+        ILogger<StatisticService> logger)
     {
         _toDosDataController = toDosDataController;
         _timeLogsDataController = timeLogsDataController;
+        _logger = logger;
     }
 
-    public async Task<List<ToDoCountStatisticsOfAllTime>> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId)
+    public async Task<List<ToDoCountStatisticsOfAllTime>> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId, Guid currentUserId, bool isAdmin)
     {
+        if (userId == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+        if (userId != currentUserId && !isAdmin)
+            throw new ForbiddenException();
+
         var result = new List<ToDoCountStatisticsOfAllTime>();
         foreach (var status in Enum.GetValues<ToDoStatus>())
         {
@@ -25,46 +37,63 @@ public class StatisticService : IStatisticService
         return result;
     }
 
+    public async Task<MainPageStatisticModel?> GetMainPageStatistic(MainPageStatisticRequest filter, Guid currentUserId, bool isAdmin)
+    {
+        if (filter.UserId == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+        if (filter.UserId != currentUserId && !isAdmin)
+            throw new ForbiddenException();
+
+        try
+        {
+            var timeLogsForFilterTime = await _timeLogsDataController.GetTimeLogsByUserIdAndTime(filter.UserId, GetFilterDaysAgo(filter.TimeFilter));
+            var daysIntoCurrentMonth = (int)(DateTime.UtcNow - new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc)).TotalDays;
+            var timeLogsForThisMonth = await _timeLogsDataController.GetTimeLogsByUserIdAndTime(filter.UserId, daysIntoCurrentMonth);
+            var toDosForNearestDueDate = await _toDosDataController.GetToDosByNearestDueDateByUserId(filter.UserId);
+            var toDoCountStatisticsOfAllTimes = new List<ToDoCountStatisticsOfAllTime>();
+            await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.New, toDoCountStatisticsOfAllTimes);
+            await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.InProgress, toDoCountStatisticsOfAllTimes);
+            await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.Completed, toDoCountStatisticsOfAllTimes);
+            await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.Cancelled, toDoCountStatisticsOfAllTimes);
+
+            return new MainPageStatisticModel
+            {
+                TimeLogsForGivenTime = timeLogsForFilterTime.Select(x => x.ToTimeLog()).ToList(),
+                TimeLogsForThisMonth = timeLogsForThisMonth.Select(x => x.ToTimeLog()).ToList(),
+                DueDateTasks         = toDosForNearestDueDate.ToDictionary(x => x.DueDate!.Value, x => x),
+                ToDoStatuses         = toDoCountStatisticsOfAllTimes
+            };
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return null;
+        }
+    }
+
     private async Task GetCountOfStatusesByStatus(Guid userId, ToDoStatus status, List<ToDoCountStatisticsOfAllTime> result)
     {
         var count = await _toDosDataController.GetToDosCountByUserIdAndStatus(userId, status);
         result.Add(new ToDoCountStatisticsOfAllTime
         {
             ToDoStatus = status,
-            Count = count
+            Count      = count
         });
-    }
-
-    public async Task<MainPageStatisticModel?> GetMainPageStatistic(MainPageStatisticRequest filter)
-    {
-        var timeLogsForFilterTime = await _timeLogsDataController.GetTimeLogsByUserIdAndTime(filter.UserId, GetFilterDaysAgo(filter.TimeFilter));
-        var daysIntoCurrentMonth = (int)(DateTime.UtcNow - new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc)).TotalDays;
-        var timeLogsForThisMonth = await _timeLogsDataController.GetTimeLogsByUserIdAndTime(filter.UserId, daysIntoCurrentMonth);
-        var toDosForNearestDueDate = await _toDosDataController.GetToDosByNearestDueDateByUserId(filter.UserId);
-        var toDoCountStatisticsOfAllTimes = new List<ToDoCountStatisticsOfAllTime>();
-        await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.New, toDoCountStatisticsOfAllTimes);
-        await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.InProgress, toDoCountStatisticsOfAllTimes);
-        await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.Completed, toDoCountStatisticsOfAllTimes);
-        await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.Cancelled, toDoCountStatisticsOfAllTimes);
-
-        return new MainPageStatisticModel()
-        {
-            TimeLogsForGivenTime = timeLogsForFilterTime.Select(x => x.ToTimeLog()).ToList(),
-            TimeLogsForThisMonth = timeLogsForThisMonth.Select(x => x.ToTimeLog()).ToList(),
-            DueDateTasks = toDosForNearestDueDate.ToDictionary(x => x.DueDate!.Value, x => x),
-            ToDoStatuses = toDoCountStatisticsOfAllTimes
-        };
     }
 
     private static int GetFilterDaysAgo(TimeFilter filterTimeFilter)
     {
         return filterTimeFilter switch
         {
-            TimeFilter.DayAgo => 1,
-            TimeFilter.WeekAgo => 7,
+            TimeFilter.DayAgo   => 1,
+            TimeFilter.WeekAgo  => 7,
             TimeFilter.MonthAgo => 30,
-            TimeFilter.YearAgo => 365,
-            _ => -1
+            TimeFilter.YearAgo  => 365,
+            _                   => -1
         };
     }
 }

--- a/ToDoTimeManager.WebApi/Services/Implementations/TeamsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TeamsService.cs
@@ -2,6 +2,7 @@ using ToDoTimeManager.Shared.DTOs;
 using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Exceptions;
 using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
@@ -32,14 +33,37 @@ public class TeamsService : ITeamsService
         return entities.Select(e => MapToDto(e.ToTeam(), null)).ToList();
     }
 
-    public async Task<TeamResponseDto?> GetTeamById(Guid teamId)
+    public async Task<TeamResponseDto?> GetTeamById(Guid teamId, Guid currentUserId, bool isAdmin)
     {
-        var entity = await _teamsDataController.GetTeamById(teamId);
-        if (entity == null) return null;
+        if (teamId == Guid.Empty)
+            throw new ValidationException("Invalid team ID");
 
-        var memberEntities = await _teamMembersDataController.GetMembersByTeamId(teamId);
-        var members = memberEntities.Select(m => m.ToTeamMember()).ToList();
-        return MapToDto(entity.ToTeam(), members);
+        try
+        {
+            var entity = await _teamsDataController.GetTeamById(teamId);
+            if (entity == null)
+                throw new NotFoundException("Team was not found");
+
+            if (!isAdmin)
+            {
+                var membership = await _teamMembersDataController.GetMemberByTeamIdAndUserId(teamId, currentUserId);
+                if (membership == null)
+                    throw new ForbiddenException();
+            }
+
+            var memberEntities = await _teamMembersDataController.GetMembersByTeamId(teamId);
+            var members = memberEntities.Select(m => m.ToTeamMember()).ToList();
+            return MapToDto(entity.ToTeam(), members);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return null;
+        }
     }
 
     public async Task<List<TeamResponseDto>> GetTeamsByUserId(Guid userId)
@@ -50,6 +74,9 @@ public class TeamsService : ITeamsService
 
     public async Task<bool> CreateTeam(CreateTeamRequestDto request, Guid createdByUserId)
     {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new ValidationException("Team name is required");
+
         var teamEntity = new TeamEntity
         {
             Id          = request.Id,
@@ -59,86 +86,193 @@ public class TeamsService : ITeamsService
             CreatedBy   = createdByUserId
         };
 
-        var teamCreated = await _teamsDataController.CreateTeam(teamEntity);
-        if (!teamCreated)
+        try
         {
-            _logger.LogError("Failed to create team {TeamId}", request.Id);
+            var teamCreated = await _teamsDataController.CreateTeam(teamEntity);
+            if (!teamCreated)
+            {
+                _logger.LogError("Failed to create team {TeamId}", request.Id);
+                return false;
+            }
+
+            var ownerMember = new TeamMemberEntity
+            {
+                Id     = Guid.NewGuid(),
+                TeamId = request.Id,
+                UserId = createdByUserId,
+                Role   = TeamMemberRole.Owner
+            };
+
+            var ownerAdded = await _teamMembersDataController.AddMember(ownerMember);
+            if (!ownerAdded)
+                _logger.LogError("Team {TeamId} created but failed to add owner {UserId}", request.Id, createdByUserId);
+
+            return ownerAdded;
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
             return false;
         }
-
-        var ownerMember = new TeamMemberEntity
-        {
-            Id     = Guid.NewGuid(),
-            TeamId = request.Id,
-            UserId = createdByUserId,
-            Role   = TeamMemberRole.Owner
-        };
-
-        var ownerAdded = await _teamMembersDataController.AddMember(ownerMember);
-        if (!ownerAdded)
-            _logger.LogError("Team {TeamId} created but failed to add owner {UserId}", request.Id, createdByUserId);
-
-        return ownerAdded;
     }
 
-    public async Task<bool> UpdateTeam(UpdateTeamRequestDto request)
+    public async Task<bool> UpdateTeam(UpdateTeamRequestDto request, Guid currentUserId, bool isAdmin)
     {
-        var entity = new TeamEntity
+        if (request.Id == Guid.Empty)
+            throw new ValidationException("Invalid team ID");
+
+        try
         {
-            Id          = request.Id,
-            Name        = request.Name,
-            Description = request.Description
-        };
-        return await _teamsDataController.UpdateTeam(entity);
+            if (!isAdmin)
+            {
+                var membership = await _teamMembersDataController.GetMemberByTeamIdAndUserId(request.Id, currentUserId);
+                if (membership == null || membership.Role != TeamMemberRole.Owner)
+                    throw new ForbiddenException();
+            }
+
+            var entity = new TeamEntity
+            {
+                Id          = request.Id,
+                Name        = request.Name,
+                Description = request.Description
+            };
+            return await _teamsDataController.UpdateTeam(entity);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
     }
 
     public async Task<bool> DeleteTeam(Guid teamId)
     {
-        return await _teamsDataController.DeleteTeam(teamId);
-    }
+        if (teamId == Guid.Empty)
+            throw new ValidationException("Invalid team ID");
 
-    public async Task<bool> AddMember(TeamMemberUpsertRequestDto request)
-    {
-        var existing = await _teamMembersDataController.GetMemberByTeamIdAndUserId(request.TeamId, request.UserId);
-        if (existing != null) return false;
-
-        var entity = new TeamMemberEntity
+        try
         {
-            Id     = request.Id,
-            TeamId = request.TeamId,
-            UserId = request.UserId,
-            Role   = request.Role
-        };
-        return await _teamMembersDataController.AddMember(entity);
-    }
-
-    public async Task<bool> RemoveMember(Guid teamId, Guid userId)
-    {
-        var members = await _teamMembersDataController.GetMembersByTeamId(teamId);
-        var owners = members.Where(m => m.Role == TeamMemberRole.Owner).ToList();
-
-        var targetMember = members.FirstOrDefault(m => m.UserId == userId);
-        if (targetMember == null) return false;
-
-        if (targetMember.Role == TeamMemberRole.Owner && owners.Count == 1)
+            return await _teamsDataController.DeleteTeam(teamId);
+        }
+        catch (ServiceException)
         {
-            _logger.LogWarning("Cannot remove the last owner of team {TeamId}", teamId);
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
             return false;
         }
-
-        return await _teamMembersDataController.RemoveMember(teamId, userId);
     }
 
-    public async Task<TeamMember?> GetMembership(Guid teamId, Guid userId)
+    public async Task<bool> AddMember(TeamMemberUpsertRequestDto request, Guid currentUserId, bool isAdmin)
     {
-        var entity = await _teamMembersDataController.GetMemberByTeamIdAndUserId(teamId, userId);
-        return entity?.ToTeamMember();
+        if (request.TeamId == Guid.Empty)
+            throw new ValidationException("Invalid team ID");
+
+        try
+        {
+            if (!isAdmin)
+            {
+                var callerMembership = await _teamMembersDataController.GetMemberByTeamIdAndUserId(request.TeamId, currentUserId);
+                if (callerMembership == null || callerMembership.Role != TeamMemberRole.Owner)
+                    throw new ForbiddenException();
+            }
+
+            var existing = await _teamMembersDataController.GetMemberByTeamIdAndUserId(request.TeamId, request.UserId);
+            if (existing != null)
+                throw new ConflictException("User is already a member of this team");
+
+            var entity = new TeamMemberEntity
+            {
+                Id     = request.Id,
+                TeamId = request.TeamId,
+                UserId = request.UserId,
+                Role   = request.Role
+            };
+            return await _teamMembersDataController.AddMember(entity);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
     }
 
-    public async Task<List<ToDo>> GetToDosByTeamId(Guid teamId)
+    public async Task<bool> RemoveMember(Guid teamId, Guid userId, Guid currentUserId, bool isAdmin)
     {
-        var entities = await _toDosDataController.GetToDosByTeamId(teamId);
-        return entities.Select(e => e.ToToDo()).ToList();
+        if (teamId == Guid.Empty || userId == Guid.Empty)
+            throw new ValidationException("Invalid team or user ID");
+
+        try
+        {
+            if (!isAdmin)
+            {
+                var callerMembership = await _teamMembersDataController.GetMemberByTeamIdAndUserId(teamId, currentUserId);
+                if (callerMembership == null || callerMembership.Role != TeamMemberRole.Owner)
+                    throw new ForbiddenException();
+            }
+
+            var members = await _teamMembersDataController.GetMembersByTeamId(teamId);
+            var targetMember = members.FirstOrDefault(m => m.UserId == userId);
+            if (targetMember == null)
+                throw new NotFoundException("Member was not found in this team");
+
+            var owners = members.Where(m => m.Role == TeamMemberRole.Owner).ToList();
+            if (targetMember.Role == TeamMemberRole.Owner && owners.Count == 1)
+                throw new ConflictException("Cannot remove the last owner of a team");
+
+            return await _teamMembersDataController.RemoveMember(teamId, userId);
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
+    }
+
+    public async Task<List<ToDo>> GetToDosByTeamId(Guid teamId, Guid currentUserId, bool isAdmin)
+    {
+        if (teamId == Guid.Empty)
+            throw new ValidationException("Invalid team ID");
+
+        try
+        {
+            if (!isAdmin)
+            {
+                var membership = await _teamMembersDataController.GetMemberByTeamIdAndUserId(teamId, currentUserId);
+                if (membership == null)
+                    throw new ForbiddenException();
+            }
+
+            var entities = await _toDosDataController.GetToDosByTeamId(teamId);
+            return entities.Select(e => e.ToToDo()).ToList();
+        }
+        catch (ServiceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
     }
 
     private static TeamResponseDto MapToDto(Team team, List<TeamMember>? members) => new()

--- a/ToDoTimeManager.WebApi/Services/Implementations/TimeLogsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TimeLogsService.cs
@@ -1,5 +1,6 @@
-﻿using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Exceptions;
 using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
@@ -9,6 +10,7 @@ public class TimeLogsService : ITimeLogsService
 {
     private readonly ITimeLogsDataController _timeLogsDataController;
     private readonly ILogger<TimeLogsService> _logger;
+
     public TimeLogsService(ITimeLogsDataController timeLogsDataController, ILogger<TimeLogsService> logger)
     {
         _timeLogsDataController = timeLogsDataController;
@@ -29,12 +31,25 @@ public class TimeLogsService : ITimeLogsService
         }
     }
 
-    public async Task<TimeLog?> GetTimeLogById(Guid timeLogId)
+    public async Task<TimeLog?> GetTimeLogById(Guid timeLogId, Guid currentUserId, bool isAdmin)
     {
+        if (timeLogId == Guid.Empty)
+            throw new ValidationException("Invalid time log ID");
+
         try
         {
             var res = await _timeLogsDataController.GetTimeLogById(timeLogId);
-            return res?.ToTimeLog();
+            if (res == null)
+                throw new NotFoundException("Time log was not found");
+
+            if (res.UserId != currentUserId && !isAdmin)
+                throw new ForbiddenException();
+
+            return res.ToTimeLog();
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -45,11 +60,18 @@ public class TimeLogsService : ITimeLogsService
 
     public async Task<List<TimeLog>> GetTimeLogsByToDoId(Guid toDoId)
     {
+        if (toDoId == Guid.Empty)
+            throw new ValidationException("Invalid to-do ID");
+
         try
         {
             var res = await _timeLogsDataController.GetTimeLogsByToDoId(toDoId);
             return res.Select(tle => tle.ToTimeLog()).ToList()!;
         }
+        catch (ServiceException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             _logger.LogError(e, e.Message);
@@ -57,13 +79,22 @@ public class TimeLogsService : ITimeLogsService
         }
     }
 
-    public async Task<List<TimeLog>> GetTimeLogsByUserId(Guid userId)
+    public async Task<List<TimeLog>> GetTimeLogsByUserId(Guid userId, Guid currentUserId, bool isAdmin)
     {
+        if (userId == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+        if (userId != currentUserId && !isAdmin)
+            throw new ForbiddenException();
+
         try
         {
             var res = await _timeLogsDataController.GetTimeLogsByUserId(userId);
             return res.Select(tle => tle.ToTimeLog()).ToList()!;
         }
+        catch (ServiceException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             _logger.LogError(e, e.Message);
@@ -71,12 +102,23 @@ public class TimeLogsService : ITimeLogsService
         }
     }
 
-    public async Task<List<TimeLog>> GetTimeLogsByUserIdAndToDoId(Guid toDoId, Guid userId)
+    public async Task<List<TimeLog>> GetTimeLogsByUserIdAndToDoId(Guid toDoId, Guid userId, Guid currentUserId, bool isAdmin)
     {
+        if (userId == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+        if (toDoId == Guid.Empty)
+            throw new ValidationException("Invalid to-do ID");
+        if (userId != currentUserId && !isAdmin)
+            throw new ForbiddenException();
+
         try
         {
             var res = await _timeLogsDataController.GetTimeLogsByUserIdAndToDoId(toDoId, userId);
             return res.Select(tle => tle.ToTimeLog()).ToList()!;
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -98,11 +140,22 @@ public class TimeLogsService : ITimeLogsService
         }
     }
 
-    public async Task<bool> UpdateTimeLog(TimeLog updatedTimeLog)
+    public async Task<bool> UpdateTimeLog(TimeLog updatedTimeLog, Guid currentUserId, bool isAdmin)
     {
         try
         {
+            var existing = await _timeLogsDataController.GetTimeLogById(updatedTimeLog.Id);
+            if (existing == null)
+                throw new NotFoundException("Time log was not found");
+
+            if (existing.UserId != currentUserId && !isAdmin)
+                throw new ForbiddenException();
+
             return await _timeLogsDataController.UpdateTimeLog(new TimeLogEntity(updatedTimeLog));
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -111,11 +164,25 @@ public class TimeLogsService : ITimeLogsService
         }
     }
 
-    public async Task<bool> DeleteTimeLog(Guid timeLogId)
+    public async Task<bool> DeleteTimeLog(Guid timeLogId, Guid currentUserId, bool isAdmin)
     {
+        if (timeLogId == Guid.Empty)
+            throw new ValidationException("Invalid time log ID");
+
         try
         {
+            var existing = await _timeLogsDataController.GetTimeLogById(timeLogId);
+            if (existing == null)
+                throw new NotFoundException("Time log was not found");
+
+            if (existing.UserId != currentUserId && !isAdmin)
+                throw new ForbiddenException();
+
             return await _timeLogsDataController.DeleteTimeLog(timeLogId);
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/ToDoTimeManager.WebApi/Services/Implementations/ToDosService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/ToDosService.cs
@@ -1,5 +1,6 @@
-﻿using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Exceptions;
 using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
@@ -7,7 +8,6 @@ namespace ToDoTimeManager.WebApi.Services.Implementations;
 
 public class ToDosService : IToDosService
 {
-
     private readonly IToDosDataController _toDosDataController;
     private readonly ILogger<ToDosService> _logger;
 
@@ -16,6 +16,7 @@ public class ToDosService : IToDosService
         _toDosDataController = toDosDataController;
         _logger = logger;
     }
+
     public async Task<List<ToDo>> GetAllToDos()
     {
         try
@@ -30,12 +31,25 @@ public class ToDosService : IToDosService
         }
     }
 
-    public async Task<ToDo?> GetToDoById(Guid toDoId)
+    public async Task<ToDo?> GetToDoById(Guid toDoId, Guid currentUserId, bool isAdmin)
     {
+        if (toDoId == Guid.Empty)
+            throw new ValidationException("Invalid to-do ID");
+
         try
         {
             var res = await _toDosDataController.GetToDoById(toDoId);
-            return res?.ToToDo();
+            if (res == null)
+                throw new NotFoundException("To-do was not found");
+
+            if (res.AssignedTo != currentUserId && !isAdmin)
+                throw new ForbiddenException();
+
+            return res.ToToDo();
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -44,12 +58,21 @@ public class ToDosService : IToDosService
         }
     }
 
-    public async Task<List<ToDo>> GetToDosByUserId(Guid userId)
+    public async Task<List<ToDo>> GetToDosByUserId(Guid userId, Guid currentUserId, bool isAdmin)
     {
+        if (userId == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+        if (userId != currentUserId && !isAdmin)
+            throw new ForbiddenException();
+
         try
         {
             var res = await _toDosDataController.GetToDosByUserId(userId);
             return res.Select(tde => tde.ToToDo()).ToList();
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -60,10 +83,17 @@ public class ToDosService : IToDosService
 
     public async Task<bool> CreateToDo(ToDo newToDo)
     {
+        if (string.IsNullOrWhiteSpace(newToDo.Title))
+            throw new ValidationException("To-do title is required");
+
         try
         {
             return await _toDosDataController.CreateToDo(new ToDoEntity(newToDo));
         }
+        catch (ServiceException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             _logger.LogError(e, e.Message);
@@ -71,12 +101,23 @@ public class ToDosService : IToDosService
         }
     }
 
-    public async Task<bool> UpdateToDo(ToDo updatedToDo)
+    public async Task<bool> UpdateToDo(ToDo updatedToDo, Guid currentUserId, bool isAdmin)
     {
         try
         {
+            var existing = await _toDosDataController.GetToDoById(updatedToDo.Id);
+            if (existing == null)
+                throw new NotFoundException("To-do was not found");
+
+            if (existing.AssignedTo != currentUserId && !isAdmin)
+                throw new ForbiddenException();
+
             return await _toDosDataController.UpdateToDo(new ToDoEntity(updatedToDo));
         }
+        catch (ServiceException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             _logger.LogError(e, e.Message);
@@ -84,11 +125,25 @@ public class ToDosService : IToDosService
         }
     }
 
-    public async Task<bool> DeleteToDo(Guid toDoId)
+    public async Task<bool> DeleteToDo(Guid toDoId, Guid currentUserId, bool isAdmin)
     {
+        if (toDoId == Guid.Empty)
+            throw new ValidationException("Invalid to-do ID");
+
         try
         {
+            var existing = await _toDosDataController.GetToDoById(toDoId);
+            if (existing == null)
+                throw new NotFoundException("To-do was not found");
+
+            if (existing.AssignedTo != currentUserId && !isAdmin)
+                throw new ForbiddenException();
+
             return await _toDosDataController.DeleteToDo(toDoId);
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/ToDoTimeManager.WebApi/Services/Implementations/UsersService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/UsersService.cs
@@ -1,6 +1,8 @@
-﻿using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Exceptions;
 using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 using ToDoTimeManager.WebApi.Utils.Interfaces;
@@ -9,7 +11,6 @@ namespace ToDoTimeManager.WebApi.Services.Implementations;
 
 public class UsersService : IUsersService
 {
-
     private readonly IUsersDataController _usersDataController;
     private readonly ILogger<UsersService> _logger;
     private readonly IPasswordHelperService _passwordHelperService;
@@ -35,12 +36,25 @@ public class UsersService : IUsersService
         }
     }
 
-    public async Task<User?> GetUserById(Guid userId)
+    public async Task<User?> GetUserById(Guid userId, Guid currentUserId, bool isAdmin)
     {
+        if (userId == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+
         try
         {
             var res = await _usersDataController.GetUserById(userId);
-            return res?.ToUser();
+            if (res == null)
+                throw new NotFoundException("User was not found");
+
+            if (userId != currentUserId && !isAdmin)
+                throw new ForbiddenException();
+
+            return res.ToUser();
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -51,10 +65,19 @@ public class UsersService : IUsersService
 
     public async Task<User?> GetUserByUsername(string username)
     {
+        if (string.IsNullOrWhiteSpace(username))
+            throw new ValidationException("Invalid username");
+
         try
         {
             var res = await _usersDataController.GetUserByUsername(username);
-            return res?.ToUser();
+            if (res == null)
+                throw new NotFoundException("User was not found");
+            return res.ToUser();
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -65,10 +88,19 @@ public class UsersService : IUsersService
 
     public async Task<User?> GetUserByEmail(string email)
     {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ValidationException("Invalid email");
+
         try
         {
             var res = await _usersDataController.GetUserByEmail(email);
-            return res?.ToUser();
+            if (res == null)
+                throw new NotFoundException("User was not found");
+            return res.ToUser();
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -79,10 +111,19 @@ public class UsersService : IUsersService
 
     public async Task<User?> GetUserByLoginParameter(string loginParameter)
     {
+        if (string.IsNullOrWhiteSpace(loginParameter))
+            throw new ValidationException("Invalid login parameter");
+
         try
         {
             var res = await _usersDataController.GetUserByLoginParameter(loginParameter);
-            return res?.ToUser();
+            if (res == null)
+                throw new NotFoundException("User was not found");
+            return res.ToUser();
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -91,12 +132,39 @@ public class UsersService : IUsersService
         }
     }
 
-    public async Task<bool> CreateUser(User newUser)
+    public async Task<bool> CreateUser(CreateUserRequestDto request)
     {
+        if (string.IsNullOrWhiteSpace(request.UserName))
+            throw new ValidationException("Username is required");
+        if (string.IsNullOrWhiteSpace(request.Email))
+            throw new ValidationException("Email is required");
+        if (string.IsNullOrWhiteSpace(request.Password))
+            throw new ValidationException("Password is required");
+
         try
         {
-            newUser.Password = _passwordHelperService.HashPassword(newUser.Id.ToString(), newUser.Password!);
-            return await _usersDataController.CreateUser(new UserEntity(newUser));
+            var existingByUsername = await _usersDataController.GetUserByUsername(request.UserName);
+            if (existingByUsername != null)
+                throw new ConflictException("Username is already taken");
+
+            var existingByEmail = await _usersDataController.GetUserByEmail(request.Email);
+            if (existingByEmail != null)
+                throw new ConflictException("Email is already registered");
+
+            var user = new User
+            {
+                Id       = request.Id,
+                UserName = request.UserName,
+                Email    = request.Email,
+                Password = _passwordHelperService.HashPassword(request.Id.ToString(), request.Password),
+                UserRole = UserRole.User
+            };
+
+            return await _usersDataController.CreateUser(new UserEntity(user));
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -105,11 +173,40 @@ public class UsersService : IUsersService
         }
     }
 
-    public async Task<bool> UpdateUser(User updatedUser)
+    public async Task<bool> UpdateUser(UpdateUserRequestDto request, Guid currentUserId)
     {
+        if (request.Id == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+        if (request.Id != currentUserId)
+            throw new ForbiddenException();
+
         try
         {
-            return await _usersDataController.UpdateUser(new UserEntity(updatedUser));
+            var existing = await _usersDataController.GetUserById(request.Id);
+            if (existing == null)
+                throw new NotFoundException("User was not found");
+
+            var passwordHash = !string.IsNullOrWhiteSpace(request.Password)
+                ? _passwordHelperService.HashPassword(request.Id.ToString(), request.Password)
+                : existing.Password;
+
+            if (string.IsNullOrWhiteSpace(passwordHash))
+                throw new ValidationException("User password is missing");
+
+            var updatedEntity = new UserEntity
+            {
+                Id       = request.Id,
+                UserName = request.UserName,
+                Email    = request.Email,
+                UserRole = existing.UserRole,
+                Password = passwordHash
+            };
+
+            return await _usersDataController.UpdateUser(updatedEntity);
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -120,12 +217,21 @@ public class UsersService : IUsersService
 
     public async Task<bool> ChangeUserRole(Guid userId, UserRole newRole)
     {
+        if (userId == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+
         try
         {
             var existing = await _usersDataController.GetUserById(userId);
-            if (existing is null) return false;
+            if (existing == null)
+                throw new NotFoundException("User was not found");
+
             existing.UserRole = newRole;
             return await _usersDataController.UpdateUser(existing);
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -136,9 +242,20 @@ public class UsersService : IUsersService
 
     public async Task<bool> DeleteUser(Guid userId)
     {
+        if (userId == Guid.Empty)
+            throw new ValidationException("Invalid user ID");
+
         try
         {
+            var existing = await _usersDataController.GetUserById(userId);
+            if (existing == null)
+                throw new NotFoundException("User was not found");
+
             return await _usersDataController.DeleteUser(userId);
+        }
+        catch (ServiceException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IAuthService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IAuthService.cs
@@ -1,9 +1,9 @@
-﻿using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.WebApi.Services.Interfaces;
 
 public interface IAuthService
 {
-    TokenModel? AuthenticateUser(LoginUser loginUser, User user);
+    Task<TokenModel?> Login(LoginUser loginUser);
     TokenModel? RefreshAuthToken(TokenModel tokenModel);
 }

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IProjectsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IProjectsService.cs
@@ -6,14 +6,12 @@ namespace ToDoTimeManager.WebApi.Services.Interfaces;
 public interface IProjectsService
 {
     Task<List<ProjectResponseDto>> GetAllProjects();
-    Task<ProjectResponseDto?>      GetProjectById(Guid projectId);
+    Task<ProjectResponseDto?>      GetProjectById(Guid projectId, Guid currentUserId, bool isAdmin);
     Task<List<ProjectResponseDto>> GetProjectsByUserId(Guid userId);
     Task<bool>                     CreateProject(CreateProjectRequestDto request, Guid createdByUserId);
-    Task<bool>                     UpdateProject(UpdateProjectRequestDto request);
+    Task<bool>                     UpdateProject(UpdateProjectRequestDto request, Guid currentUserId, bool isAdmin);
     Task<bool>                     DeleteProject(Guid projectId);
-    Task<bool>                     AddTeam(ProjectTeamUpsertRequestDto request);
-    Task<bool>                     RemoveTeam(Guid projectId, Guid teamId);
-    Task<ProjectTeam?>             GetProjectTeam(Guid projectId, Guid teamId);
-    Task<List<ToDo>>               GetToDosByProjectId(Guid projectId);
-    Task<bool>                     UserHasAccessToProject(Guid projectId, Guid userId);
+    Task<bool>                     AddTeam(ProjectTeamUpsertRequestDto request, Guid currentUserId, bool isAdmin);
+    Task<bool>                     RemoveTeam(Guid projectId, Guid teamId, Guid currentUserId, bool isAdmin);
+    Task<List<ToDo>>               GetToDosByProjectId(Guid projectId, Guid currentUserId, bool isAdmin);
 }

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IStatisticService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IStatisticService.cs
@@ -1,9 +1,9 @@
-﻿using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.WebApi.Services.Interfaces;
 
 public interface IStatisticService
 {
-    Task<List<ToDoCountStatisticsOfAllTime>> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId);
-    Task<MainPageStatisticModel?> GetMainPageStatistic(MainPageStatisticRequest filter);
+    Task<List<ToDoCountStatisticsOfAllTime>> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId, Guid currentUserId, bool isAdmin);
+    Task<MainPageStatisticModel?> GetMainPageStatistic(MainPageStatisticRequest filter, Guid currentUserId, bool isAdmin);
 }

--- a/ToDoTimeManager.WebApi/Services/Interfaces/ITeamsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/ITeamsService.cs
@@ -6,13 +6,12 @@ namespace ToDoTimeManager.WebApi.Services.Interfaces;
 public interface ITeamsService
 {
     Task<List<TeamResponseDto>> GetAllTeams();
-    Task<TeamResponseDto?>      GetTeamById(Guid teamId);
+    Task<TeamResponseDto?>      GetTeamById(Guid teamId, Guid currentUserId, bool isAdmin);
     Task<List<TeamResponseDto>> GetTeamsByUserId(Guid userId);
     Task<bool>                  CreateTeam(CreateTeamRequestDto request, Guid createdByUserId);
-    Task<bool>                  UpdateTeam(UpdateTeamRequestDto request);
+    Task<bool>                  UpdateTeam(UpdateTeamRequestDto request, Guid currentUserId, bool isAdmin);
     Task<bool>                  DeleteTeam(Guid teamId);
-    Task<bool>                  AddMember(TeamMemberUpsertRequestDto request);
-    Task<bool>                  RemoveMember(Guid teamId, Guid userId);
-    Task<TeamMember?>           GetMembership(Guid teamId, Guid userId);
-    Task<List<ToDo>>            GetToDosByTeamId(Guid teamId);
+    Task<bool>                  AddMember(TeamMemberUpsertRequestDto request, Guid currentUserId, bool isAdmin);
+    Task<bool>                  RemoveMember(Guid teamId, Guid userId, Guid currentUserId, bool isAdmin);
+    Task<List<ToDo>>            GetToDosByTeamId(Guid teamId, Guid currentUserId, bool isAdmin);
 }

--- a/ToDoTimeManager.WebApi/Services/Interfaces/ITimeLogsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/ITimeLogsService.cs
@@ -1,15 +1,15 @@
-﻿using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.WebApi.Services.Interfaces;
 
 public interface ITimeLogsService
 {
     Task<List<TimeLog>> GetAllTimeLogs();
-    Task<TimeLog?> GetTimeLogById(Guid timeLogId);
+    Task<TimeLog?> GetTimeLogById(Guid timeLogId, Guid currentUserId, bool isAdmin);
     Task<List<TimeLog>> GetTimeLogsByToDoId(Guid toDoId);
-    Task<List<TimeLog>> GetTimeLogsByUserId(Guid userId);
-    Task<List<TimeLog>> GetTimeLogsByUserIdAndToDoId(Guid toDoId, Guid userId);
+    Task<List<TimeLog>> GetTimeLogsByUserId(Guid userId, Guid currentUserId, bool isAdmin);
+    Task<List<TimeLog>> GetTimeLogsByUserIdAndToDoId(Guid toDoId, Guid userId, Guid currentUserId, bool isAdmin);
     Task<bool> CreateTimeLog(TimeLog newTimeLog);
-    Task<bool> UpdateTimeLog(TimeLog updatedTimeLog);
-    Task<bool> DeleteTimeLog(Guid timeLogId);
+    Task<bool> UpdateTimeLog(TimeLog updatedTimeLog, Guid currentUserId, bool isAdmin);
+    Task<bool> DeleteTimeLog(Guid timeLogId, Guid currentUserId, bool isAdmin);
 }

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IToDosService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IToDosService.cs
@@ -1,13 +1,13 @@
-﻿using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.WebApi.Services.Interfaces;
 
 public interface IToDosService
 {
     Task<List<ToDo>> GetAllToDos();
-    Task<ToDo?> GetToDoById(Guid toDoId);
-    Task<List<ToDo>> GetToDosByUserId(Guid userId);
+    Task<ToDo?> GetToDoById(Guid toDoId, Guid currentUserId, bool isAdmin);
+    Task<List<ToDo>> GetToDosByUserId(Guid userId, Guid currentUserId, bool isAdmin);
     Task<bool> CreateToDo(ToDo newToDo);
-    Task<bool> UpdateToDo(ToDo updatedToDo);
-    Task<bool> DeleteToDo(Guid toDoId);
+    Task<bool> UpdateToDo(ToDo updatedToDo, Guid currentUserId, bool isAdmin);
+    Task<bool> DeleteToDo(Guid toDoId, Guid currentUserId, bool isAdmin);
 }

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IUsersService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IUsersService.cs
@@ -1,4 +1,5 @@
-﻿using ToDoTimeManager.Shared.Enums;
+using ToDoTimeManager.Shared.DTOs;
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.WebApi.Services.Interfaces;
@@ -6,12 +7,12 @@ namespace ToDoTimeManager.WebApi.Services.Interfaces;
 public interface IUsersService
 {
     Task<List<User>> GetAllUsers();
-    Task<User?> GetUserById(Guid userId);
+    Task<User?> GetUserById(Guid userId, Guid currentUserId, bool isAdmin);
     Task<User?> GetUserByUsername(string username);
     Task<User?> GetUserByEmail(string email);
     Task<User?> GetUserByLoginParameter(string loginParameter);
-    Task<bool> CreateUser(User newUser);
-    Task<bool> UpdateUser(User updatedUser);
+    Task<bool> CreateUser(CreateUserRequestDto request);
+    Task<bool> UpdateUser(UpdateUserRequestDto request, Guid currentUserId);
     Task<bool> ChangeUserRole(Guid userId, UserRole newRole);
     Task<bool> DeleteUser(Guid userId);
 }


### PR DESCRIPTION
- Add ServiceException hierarchy (ValidationException/NotFoundException/ForbiddenException/ConflictException) in WebApi/Exceptions/
- Update GlobalExceptionHandler to catch ServiceException and map to correct HTTP status code (400/403/404/409)
- Each service now owns its validation (empty IDs, required fields), authorization (ownership/membership checks), and business rules (duplicate guards, last-owner constraint)
- Services throw ServiceException for intentional failures; catch-all returns null/false for unexpected infrastructure errors
- AuthService: merged Login(LoginUser) — fetches user and authenticates in one method, uses IUsersDataController directly
- UsersService: CreateUser/UpdateUser take DTOs; role hardcoding and password hashing moved from controller to service
- TeamsService/ProjectsService: removed GetMembership/UserHasAccessToProject from public interface; logic is now internal
- All controllers reduced to: extract currentUserId/isAdmin, call one service method, return Ok or StatusCode(500) for unexpected failures

https://claude.ai/code/session_013Kt8Ka21cmxk25CA5Hyw35