### PR TITLE
Refactor services to use dependency injection instead of data controllers

### DIFF
--- a/ToDoTimeManager.WebApi/Services/Implementations/ProjectsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/ProjectsService.cs
@@ -11,18 +11,18 @@ public class ProjectsService : IProjectsService
 {
     private readonly IProjectsDataController     _projectsDataController;
     private readonly IProjectTeamsDataController _projectTeamsDataController;
-    private readonly IToDosDataController        _toDosDataController;
+    private readonly IToDosService               _toDosService;
     private readonly ILogger<ProjectsService>    _logger;
 
     public ProjectsService(
         IProjectsDataController     projectsDataController,
         IProjectTeamsDataController projectTeamsDataController,
-        IToDosDataController        toDosDataController,
+        IToDosService               toDosService,
         ILogger<ProjectsService>    logger)
     {
         _projectsDataController     = projectsDataController;
         _projectTeamsDataController = projectTeamsDataController;
-        _toDosDataController        = toDosDataController;
+        _toDosService               = toDosService;
         _logger                     = logger;
     }
 
@@ -235,8 +235,7 @@ public class ProjectsService : IProjectsService
                     throw new ForbiddenException();
             }
 
-            var entities = await _toDosDataController.GetToDosByProjectId(projectId);
-            return entities.Select(e => e.ToToDo()).ToList();
+            return await _toDosService.GetToDosByProjectId(projectId);
         }
         catch (ServiceException)
         {

--- a/ToDoTimeManager.WebApi/Services/Implementations/StatisticService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/StatisticService.cs
@@ -1,25 +1,24 @@
 using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Exceptions;
-using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Services.Implementations;
 
 public class StatisticService : IStatisticService
 {
-    private readonly IToDosDataController _toDosDataController;
-    private readonly ITimeLogsDataController _timeLogsDataController;
+    private readonly IToDosService             _toDosService;
+    private readonly ITimeLogsService          _timeLogsService;
     private readonly ILogger<StatisticService> _logger;
 
     public StatisticService(
-        IToDosDataController toDosDataController,
-        ITimeLogsDataController timeLogsDataController,
+        IToDosService             toDosService,
+        ITimeLogsService          timeLogsService,
         ILogger<StatisticService> logger)
     {
-        _toDosDataController = toDosDataController;
-        _timeLogsDataController = timeLogsDataController;
-        _logger = logger;
+        _toDosService    = toDosService;
+        _timeLogsService = timeLogsService;
+        _logger          = logger;
     }
 
     public async Task<List<ToDoCountStatisticsOfAllTime>> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId, Guid currentUserId, bool isAdmin)
@@ -46,10 +45,10 @@ public class StatisticService : IStatisticService
 
         try
         {
-            var timeLogsForFilterTime = await _timeLogsDataController.GetTimeLogsByUserIdAndTime(filter.UserId, GetFilterDaysAgo(filter.TimeFilter));
+            var timeLogsForFilterTime = await _timeLogsService.GetTimeLogsByUserIdAndTime(filter.UserId, GetFilterDaysAgo(filter.TimeFilter));
             var daysIntoCurrentMonth = (int)(DateTime.UtcNow - new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc)).TotalDays;
-            var timeLogsForThisMonth = await _timeLogsDataController.GetTimeLogsByUserIdAndTime(filter.UserId, daysIntoCurrentMonth);
-            var toDosForNearestDueDate = await _toDosDataController.GetToDosByNearestDueDateByUserId(filter.UserId);
+            var timeLogsForThisMonth = await _timeLogsService.GetTimeLogsByUserIdAndTime(filter.UserId, daysIntoCurrentMonth);
+            var toDosForNearestDueDate = await _toDosService.GetToDosByNearestDueDateByUserId(filter.UserId);
             var toDoCountStatisticsOfAllTimes = new List<ToDoCountStatisticsOfAllTime>();
             await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.New, toDoCountStatisticsOfAllTimes);
             await GetCountOfStatusesByStatus(filter.UserId, ToDoStatus.InProgress, toDoCountStatisticsOfAllTimes);
@@ -58,8 +57,8 @@ public class StatisticService : IStatisticService
 
             return new MainPageStatisticModel
             {
-                TimeLogsForGivenTime = timeLogsForFilterTime.Select(x => x.ToTimeLog()).ToList(),
-                TimeLogsForThisMonth = timeLogsForThisMonth.Select(x => x.ToTimeLog()).ToList(),
+                TimeLogsForGivenTime = timeLogsForFilterTime,
+                TimeLogsForThisMonth = timeLogsForThisMonth,
                 DueDateTasks         = toDosForNearestDueDate.ToDictionary(x => x.DueDate!.Value, x => x),
                 ToDoStatuses         = toDoCountStatisticsOfAllTimes
             };
@@ -77,7 +76,7 @@ public class StatisticService : IStatisticService
 
     private async Task GetCountOfStatusesByStatus(Guid userId, ToDoStatus status, List<ToDoCountStatisticsOfAllTime> result)
     {
-        var count = await _toDosDataController.GetToDosCountByUserIdAndStatus(userId, status);
+        var count = await _toDosService.GetToDosCountByUserIdAndStatus(userId, status);
         result.Add(new ToDoCountStatisticsOfAllTime
         {
             ToDoStatus = status,

--- a/ToDoTimeManager.WebApi/Services/Implementations/TeamsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TeamsService.cs
@@ -10,21 +10,21 @@ namespace ToDoTimeManager.WebApi.Services.Implementations;
 
 public class TeamsService : ITeamsService
 {
-    private readonly ITeamsDataController _teamsDataController;
+    private readonly ITeamsDataController       _teamsDataController;
     private readonly ITeamMembersDataController _teamMembersDataController;
-    private readonly IToDosDataController _toDosDataController;
-    private readonly ILogger<TeamsService> _logger;
+    private readonly IToDosService              _toDosService;
+    private readonly ILogger<TeamsService>      _logger;
 
     public TeamsService(
-        ITeamsDataController teamsDataController,
+        ITeamsDataController       teamsDataController,
         ITeamMembersDataController teamMembersDataController,
-        IToDosDataController toDosDataController,
-        ILogger<TeamsService> logger)
+        IToDosService              toDosService,
+        ILogger<TeamsService>      logger)
     {
-        _teamsDataController = teamsDataController;
+        _teamsDataController       = teamsDataController;
         _teamMembersDataController = teamMembersDataController;
-        _toDosDataController = toDosDataController;
-        _logger = logger;
+        _toDosService              = toDosService;
+        _logger                    = logger;
     }
 
     public async Task<List<TeamResponseDto>> GetAllTeams()
@@ -261,8 +261,7 @@ public class TeamsService : ITeamsService
                     throw new ForbiddenException();
             }
 
-            var entities = await _toDosDataController.GetToDosByTeamId(teamId);
-            return entities.Select(e => e.ToToDo()).ToList();
+            return await _toDosService.GetToDosByTeamId(teamId);
         }
         catch (ServiceException)
         {

--- a/ToDoTimeManager.WebApi/Services/Implementations/TimeLogsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TimeLogsService.cs
@@ -127,6 +127,20 @@ public class TimeLogsService : ITimeLogsService
         }
     }
 
+    public async Task<List<TimeLog>> GetTimeLogsByUserIdAndTime(Guid userId, int daysAgo)
+    {
+        try
+        {
+            var res = await _timeLogsDataController.GetTimeLogsByUserIdAndTime(userId, daysAgo);
+            return res.Select(tle => tle.ToTimeLog()).ToList()!;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
+
     public async Task<bool> CreateTimeLog(TimeLog newTimeLog)
     {
         try

--- a/ToDoTimeManager.WebApi/Services/Implementations/ToDosService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/ToDosService.cs
@@ -1,3 +1,4 @@
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Entities;
 using ToDoTimeManager.WebApi.Exceptions;
@@ -78,6 +79,60 @@ public class ToDosService : IToDosService
         {
             _logger.LogError(e, e.Message);
             return [];
+        }
+    }
+
+    public async Task<List<ToDo>> GetToDosByTeamId(Guid teamId)
+    {
+        try
+        {
+            var res = await _toDosDataController.GetToDosByTeamId(teamId);
+            return res.Select(e => e.ToToDo()).ToList();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
+
+    public async Task<List<ToDo>> GetToDosByProjectId(Guid projectId)
+    {
+        try
+        {
+            var res = await _toDosDataController.GetToDosByProjectId(projectId);
+            return res.Select(e => e.ToToDo()).ToList();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
+
+    public async Task<List<ToDo>> GetToDosByNearestDueDateByUserId(Guid userId)
+    {
+        try
+        {
+            return await _toDosDataController.GetToDosByNearestDueDateByUserId(userId);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
+
+    public async Task<int> GetToDosCountByUserIdAndStatus(Guid userId, ToDoStatus status)
+    {
+        try
+        {
+            return await _toDosDataController.GetToDosCountByUserIdAndStatus(userId, status);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return 0;
         }
     }
 

--- a/ToDoTimeManager.WebApi/Services/Interfaces/ITimeLogsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/ITimeLogsService.cs
@@ -9,6 +9,7 @@ public interface ITimeLogsService
     Task<List<TimeLog>> GetTimeLogsByToDoId(Guid toDoId);
     Task<List<TimeLog>> GetTimeLogsByUserId(Guid userId, Guid currentUserId, bool isAdmin);
     Task<List<TimeLog>> GetTimeLogsByUserIdAndToDoId(Guid toDoId, Guid userId, Guid currentUserId, bool isAdmin);
+    Task<List<TimeLog>> GetTimeLogsByUserIdAndTime(Guid userId, int daysAgo);
     Task<bool> CreateTimeLog(TimeLog newTimeLog);
     Task<bool> UpdateTimeLog(TimeLog updatedTimeLog, Guid currentUserId, bool isAdmin);
     Task<bool> DeleteTimeLog(Guid timeLogId, Guid currentUserId, bool isAdmin);

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IToDosService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IToDosService.cs
@@ -1,3 +1,4 @@
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.WebApi.Services.Interfaces;
@@ -7,6 +8,10 @@ public interface IToDosService
     Task<List<ToDo>> GetAllToDos();
     Task<ToDo?> GetToDoById(Guid toDoId, Guid currentUserId, bool isAdmin);
     Task<List<ToDo>> GetToDosByUserId(Guid userId, Guid currentUserId, bool isAdmin);
+    Task<List<ToDo>> GetToDosByTeamId(Guid teamId);
+    Task<List<ToDo>> GetToDosByProjectId(Guid projectId);
+    Task<List<ToDo>> GetToDosByNearestDueDateByUserId(Guid userId);
+    Task<int> GetToDosCountByUserIdAndStatus(Guid userId, ToDoStatus status);
     Task<bool> CreateToDo(ToDo newToDo);
     Task<bool> UpdateToDo(ToDo updatedToDo, Guid currentUserId, bool isAdmin);
     Task<bool> DeleteToDo(Guid toDoId, Guid currentUserId, bool isAdmin);


### PR DESCRIPTION
## Summary
This PR refactors the service layer to follow better separation of concerns by having services depend on other services rather than directly on data controllers. This improves testability, reduces coupling, and creates a cleaner abstraction layer.

## Key Changes

- **ToDosService**: Added four new public methods to expose data controller functionality:
  - `GetToDosByTeamId(Guid teamId)` - Retrieve todos for a specific team
  - `GetToDosByProjectId(Guid projectId)` - Retrieve todos for a specific project
  - `GetToDosByNearestDueDateByUserId(Guid userId)` - Retrieve todos sorted by nearest due date
  - `GetToDosCountByUserIdAndStatus(Guid userId, ToDoStatus status)` - Get count of todos by status

- **TimeLogsService**: Added new public method:
  - `GetTimeLogsByUserIdAndTime(Guid userId, int daysAgo)` - Retrieve time logs within a specified time range

- **StatisticService**: Refactored to depend on `IToDosService` and `ITimeLogsService` instead of data controllers
  - Removed direct dependencies on `IToDosDataController` and `ITimeLogsDataController`
  - Updated all method calls to use the service layer
  - Simplified data transformation by removing unnecessary `.Select(x => x.ToTimeLog())` calls where services already return mapped objects

- **TeamsService**: Refactored to depend on `IToDosService` instead of `IToDosDataController`
  - Simplified `GetToDosByTeamId()` to delegate to the service method

- **ProjectsService**: Refactored to depend on `IToDosService` instead of `IToDosDataController`
  - Simplified `GetToDosByProjectId()` to delegate to the service method

- **Interface Updates**: Updated `IToDosService` and `ITimeLogsService` interfaces to include the new public methods

## Implementation Details

All new service methods follow the existing error handling pattern with try-catch blocks that log exceptions and return empty collections or default values on failure. This maintains consistency with the existing codebase and ensures graceful degradation.

https://claude.ai/code/session_01AGXYioGjxNdGYuR3YrDp3N