### PR TITLE
Add XML documentation to all public controller members

### DIFF
--- a/ToDoTimeManager.WebApi/Controllers/AuthController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/AuthController.cs
@@ -5,6 +5,10 @@ using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
+/// <summary>
+/// Handles authentication operations including login and token refresh.
+/// All endpoints are publicly accessible without a prior authentication token.
+/// </summary>
 [ApiController]
 [AllowAnonymous]
 [Route("api/[controller]")]
@@ -12,11 +16,23 @@ public class AuthController : ControllerBase
 {
     private readonly IAuthService _authService;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="AuthController"/>.
+    /// </summary>
+    /// <param name="authService">The authentication service used to validate credentials and issue tokens.</param>
     public AuthController(IAuthService authService)
     {
         _authService = authService;
     }
 
+    /// <summary>
+    /// Authenticates a user with their credentials and returns a JWT access token paired with a refresh token.
+    /// </summary>
+    /// <param name="loginUser">The login credentials containing a username or email and a password.</param>
+    /// <returns>
+    /// 200 OK with a <see cref="TokenModel"/> containing the access and refresh tokens on success;
+    /// 500 Internal Server Error if authentication fails.
+    /// </returns>
     [HttpPost("Login")]
     public async Task<IActionResult> Login(LoginUser? loginUser)
     {
@@ -24,6 +40,14 @@ public class AuthController : ControllerBase
         return tokenModel != null ? Ok(tokenModel) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Issues a new access token using a valid, non-expired refresh token.
+    /// </summary>
+    /// <param name="tokenModel">The current token pair containing the refresh token to exchange.</param>
+    /// <returns>
+    /// 200 OK with a refreshed <see cref="TokenModel"/> on success;
+    /// 500 Internal Server Error if the refresh token is invalid or expired.
+    /// </returns>
     [HttpPost("RefreshToken")]
     public IActionResult RefreshToken(TokenModel? tokenModel)
     {

--- a/ToDoTimeManager.WebApi/Controllers/ProjectsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/ProjectsController.cs
@@ -6,6 +6,11 @@ using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
+/// <summary>
+/// Manages projects including creation, membership, to-do retrieval, and deletion.
+/// All endpoints require an authenticated user.
+/// Operations on other users' projects are restricted to administrators or project creators.
+/// </summary>
 [Authorize]
 [ApiController]
 [Route("api/[controller]")]
@@ -13,6 +18,10 @@ public class ProjectsController : ControllerBase
 {
     private readonly IProjectsService _projectsService;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ProjectsController"/>.
+    /// </summary>
+    /// <param name="projectsService">The service used to perform project operations.</param>
     public ProjectsController(IProjectsService projectsService)
     {
         _projectsService = projectsService;
@@ -21,6 +30,10 @@ public class ProjectsController : ControllerBase
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
     private bool IsAdmin() => User.IsInRole("Admin");
 
+    /// <summary>
+    /// Retrieves all projects in the system. Restricted to administrators.
+    /// </summary>
+    /// <returns>200 OK with a list of all projects.</returns>
     [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
     public async Task<IActionResult> GetAllProjects()
@@ -29,6 +42,14 @@ public class ProjectsController : ControllerBase
         return Ok(projects);
     }
 
+    /// <summary>
+    /// Permanently deletes a project by its unique identifier. Restricted to administrators.
+    /// </summary>
+    /// <param name="id">The unique identifier of the project to delete.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if deletion fails.
+    /// </returns>
     [Authorize(Roles = "Admin")]
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteProject(Guid id)
@@ -37,6 +58,16 @@ public class ProjectsController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves a project by its unique identifier.
+    /// Administrators may access any project; regular users may only access projects
+    /// they are a member of through an assigned team.
+    /// </summary>
+    /// <param name="id">The unique identifier of the project.</param>
+    /// <returns>
+    /// 200 OK with the project details on success;
+    /// 500 Internal Server Error if the project is not found or the caller lacks access.
+    /// </returns>
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetProjectById(Guid id)
     {
@@ -44,6 +75,13 @@ public class ProjectsController : ControllerBase
         return project != null ? Ok(project) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves all to-do items that belong to a specific project.
+    /// Administrators may access any project; regular users may only access projects
+    /// they are a member of through an assigned team.
+    /// </summary>
+    /// <param name="projectId">The unique identifier of the project.</param>
+    /// <returns>200 OK with a list of to-do items for the given project.</returns>
     [HttpGet("GetToDosByProjectId/{projectId}")]
     public async Task<IActionResult> GetToDosByProjectId(Guid projectId)
     {
@@ -51,6 +89,15 @@ public class ProjectsController : ControllerBase
         return Ok(todos);
     }
 
+    /// <summary>
+    /// Updates the name and description of an existing project.
+    /// Administrators may update any project; regular users may only update projects they created.
+    /// </summary>
+    /// <param name="request">The update payload containing the project identifier, new name, and optional description.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the update fails or the caller lacks access.
+    /// </returns>
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateProject([FromBody] UpdateProjectRequestDto request)
     {
@@ -58,6 +105,15 @@ public class ProjectsController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Associates a team with a project, granting team members access to the project.
+    /// Administrators may modify any project; regular users may only modify projects they created.
+    /// </summary>
+    /// <param name="request">The payload containing the project identifier and team identifier to associate.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the operation fails or the caller lacks access.
+    /// </returns>
     [HttpPost("AddTeam")]
     public async Task<IActionResult> AddTeam([FromBody] ProjectTeamUpsertRequestDto request)
     {
@@ -65,6 +121,16 @@ public class ProjectsController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Removes a team's association from a project, revoking that team's access.
+    /// Administrators may modify any project; regular users may only modify projects they created.
+    /// </summary>
+    /// <param name="projectId">The unique identifier of the project.</param>
+    /// <param name="teamId">The unique identifier of the team to disassociate from the project.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the operation fails or the caller lacks access.
+    /// </returns>
     [HttpDelete("RemoveTeam/{projectId}/{teamId}")]
     public async Task<IActionResult> RemoveTeam(Guid projectId, Guid teamId)
     {
@@ -72,6 +138,10 @@ public class ProjectsController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves all projects that the currently authenticated user has access to via team membership.
+    /// </summary>
+    /// <returns>200 OK with a list of the current user's accessible projects.</returns>
     [HttpGet("GetMyProjects")]
     public async Task<IActionResult> GetMyProjects()
     {
@@ -79,6 +149,14 @@ public class ProjectsController : ControllerBase
         return Ok(projects);
     }
 
+    /// <summary>
+    /// Creates a new project owned by the currently authenticated user.
+    /// </summary>
+    /// <param name="request">The creation payload containing the project name and optional description.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if creation fails.
+    /// </returns>
     [HttpPost("Create")]
     public async Task<IActionResult> CreateProject([FromBody] CreateProjectRequestDto request)
     {

--- a/ToDoTimeManager.WebApi/Controllers/StatisticController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/StatisticController.cs
@@ -6,6 +6,11 @@ using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
+/// <summary>
+/// Provides aggregated statistics about to-do items and time logs.
+/// All endpoints require an authenticated user.
+/// Querying another user's statistics is restricted to administrators.
+/// </summary>
 [ApiController]
 [Route("api/[controller]")]
 [Authorize]
@@ -13,6 +18,10 @@ public class StatisticController : ControllerBase
 {
     private readonly IStatisticService _statisticService;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="StatisticController"/>.
+    /// </summary>
+    /// <param name="statisticService">The service used to compute and retrieve statistics.</param>
     public StatisticController(IStatisticService statisticService)
     {
         _statisticService = statisticService;
@@ -21,6 +30,15 @@ public class StatisticController : ControllerBase
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
     private bool IsAdmin() => User.IsInRole("Admin");
 
+    /// <summary>
+    /// Retrieves the all-time count of to-do items grouped by status for a specific user.
+    /// Administrators may query any user; regular users may only query their own statistics.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user whose statistics to retrieve.</param>
+    /// <returns>
+    /// 200 OK with a list of <see cref="ToDoCountStatisticsOfAllTime"/> entries,
+    /// one per distinct to-do status.
+    /// </returns>
     [HttpGet("GetToDoCountStatisticsOfAllTimeByUserId/{userId}")]
     public async Task<IActionResult> GetToDoCountStatisticsOfAllTimeByUserId(Guid userId)
     {
@@ -28,6 +46,19 @@ public class StatisticController : ControllerBase
         return Ok(statistics);
     }
 
+    /// <summary>
+    /// Retrieves the main dashboard statistics for a user, including time logs for a selected period,
+    /// time logs for the current month, upcoming due-date tasks, and all-time to-do status counts.
+    /// Administrators may query any user; regular users may only query their own statistics.
+    /// </summary>
+    /// <param name="filter">
+    /// The request payload specifying the target user identifier and the
+    /// <see cref="TimeFilter"/> that determines the time range for the period statistics.
+    /// </param>
+    /// <returns>
+    /// 200 OK with a <see cref="MainPageStatisticModel"/> on success;
+    /// 500 Internal Server Error if the query fails or the caller lacks access.
+    /// </returns>
     [HttpPost("GetMainPageStatistic")]
     public async Task<IActionResult> GetMainPageStatistic([FromBody] MainPageStatisticRequest filter)
     {

--- a/ToDoTimeManager.WebApi/Controllers/TeamsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/TeamsController.cs
@@ -6,6 +6,11 @@ using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
+/// <summary>
+/// Manages teams including creation, membership, to-do retrieval, and deletion.
+/// All endpoints require an authenticated user.
+/// Operations on other users' teams are restricted to administrators or team creators.
+/// </summary>
 [Authorize]
 [ApiController]
 [Route("api/[controller]")]
@@ -13,6 +18,10 @@ public class TeamsController : ControllerBase
 {
     private readonly ITeamsService _teamsService;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="TeamsController"/>.
+    /// </summary>
+    /// <param name="teamsService">The service used to perform team operations.</param>
     public TeamsController(ITeamsService teamsService)
     {
         _teamsService = teamsService;
@@ -21,6 +30,10 @@ public class TeamsController : ControllerBase
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
     private bool IsAdmin() => User.IsInRole("Admin");
 
+    /// <summary>
+    /// Retrieves all teams in the system. Restricted to administrators.
+    /// </summary>
+    /// <returns>200 OK with a list of all teams.</returns>
     [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
     public async Task<IActionResult> GetAllTeams()
@@ -29,6 +42,14 @@ public class TeamsController : ControllerBase
         return Ok(teams);
     }
 
+    /// <summary>
+    /// Permanently deletes a team by its unique identifier. Restricted to administrators.
+    /// </summary>
+    /// <param name="id">The unique identifier of the team to delete.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if deletion fails.
+    /// </returns>
     [Authorize(Roles = "Admin")]
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteTeam(Guid id)
@@ -37,6 +58,15 @@ public class TeamsController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves a team by its unique identifier.
+    /// Administrators may access any team; regular users may only access teams they are a member of.
+    /// </summary>
+    /// <param name="id">The unique identifier of the team.</param>
+    /// <returns>
+    /// 200 OK with the team details on success;
+    /// 500 Internal Server Error if the team is not found or the caller lacks access.
+    /// </returns>
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetTeamById(Guid id)
     {
@@ -44,6 +74,12 @@ public class TeamsController : ControllerBase
         return team != null ? Ok(team) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves all to-do items assigned to a specific team.
+    /// Administrators may access any team; regular users may only access teams they are a member of.
+    /// </summary>
+    /// <param name="teamId">The unique identifier of the team.</param>
+    /// <returns>200 OK with a list of to-do items for the given team.</returns>
     [HttpGet("GetToDosByTeamId/{teamId}")]
     public async Task<IActionResult> GetToDosByTeamId(Guid teamId)
     {
@@ -51,6 +87,15 @@ public class TeamsController : ControllerBase
         return Ok(todos);
     }
 
+    /// <summary>
+    /// Updates the name and description of an existing team.
+    /// Administrators may update any team; regular users may only update teams they created.
+    /// </summary>
+    /// <param name="request">The update payload containing the team identifier, new name, and optional description.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the update fails or the caller lacks access.
+    /// </returns>
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateTeam([FromBody] UpdateTeamRequestDto request)
     {
@@ -58,6 +103,15 @@ public class TeamsController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Adds a user as a member of a team with the specified role.
+    /// Administrators may modify any team; regular users may only modify teams they created.
+    /// </summary>
+    /// <param name="request">The payload containing the team identifier, user identifier, and the role to assign.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the operation fails or the caller lacks access.
+    /// </returns>
     [HttpPost("AddMember")]
     public async Task<IActionResult> AddMember([FromBody] TeamMemberUpsertRequestDto request)
     {
@@ -65,6 +119,16 @@ public class TeamsController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Removes a user from a team.
+    /// Administrators may modify any team; regular users may only modify teams they created.
+    /// </summary>
+    /// <param name="teamId">The unique identifier of the team.</param>
+    /// <param name="userId">The unique identifier of the user to remove from the team.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the operation fails or the caller lacks access.
+    /// </returns>
     [HttpDelete("RemoveMember/{teamId}/{userId}")]
     public async Task<IActionResult> RemoveMember(Guid teamId, Guid userId)
     {
@@ -72,6 +136,10 @@ public class TeamsController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves all teams that the currently authenticated user is a member of.
+    /// </summary>
+    /// <returns>200 OK with a list of the current user's teams.</returns>
     [HttpGet("GetMyTeams")]
     public async Task<IActionResult> GetMyTeams()
     {
@@ -79,6 +147,14 @@ public class TeamsController : ControllerBase
         return Ok(teams);
     }
 
+    /// <summary>
+    /// Creates a new team owned by the currently authenticated user.
+    /// </summary>
+    /// <param name="request">The creation payload containing the team name and optional description.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if creation fails.
+    /// </returns>
     [HttpPost("Create")]
     public async Task<IActionResult> CreateTeam([FromBody] CreateTeamRequestDto request)
     {

--- a/ToDoTimeManager.WebApi/Controllers/TimeLogsController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/TimeLogsController.cs
@@ -7,6 +7,11 @@ using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
+/// <summary>
+/// Manages time log entries that track hours spent on to-do items.
+/// All endpoints require an authenticated user.
+/// Access to other users' entries is restricted to administrators.
+/// </summary>
 [Authorize]
 [ApiController]
 [Route("api/[controller]")]
@@ -14,6 +19,10 @@ public class TimeLogsController : ControllerBase
 {
     private readonly ITimeLogsService _timeLogsService;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="TimeLogsController"/>.
+    /// </summary>
+    /// <param name="timeLogsService">The service used to perform time-log CRUD operations.</param>
     public TimeLogsController(ITimeLogsService timeLogsService)
     {
         _timeLogsService = timeLogsService;
@@ -22,6 +31,11 @@ public class TimeLogsController : ControllerBase
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
     private bool IsAdmin() => User.IsInRole("Admin");
 
+    /// <summary>
+    /// Retrieves every time log entry in the system across all users and to-do items.
+    /// Restricted to administrators.
+    /// </summary>
+    /// <returns>200 OK with a list of all <see cref="TimeLog"/> entries.</returns>
     [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
     public async Task<IActionResult> GetAllTimeLogs()
@@ -30,6 +44,15 @@ public class TimeLogsController : ControllerBase
         return Ok(timeLogs);
     }
 
+    /// <summary>
+    /// Retrieves a single time log entry by its unique identifier.
+    /// Administrators may access any entry; regular users may only access their own entries.
+    /// </summary>
+    /// <param name="id">The unique identifier of the time log entry.</param>
+    /// <returns>
+    /// 200 OK with the matching <see cref="TimeLog"/> on success;
+    /// 500 Internal Server Error if the entry is not found or the caller lacks access.
+    /// </returns>
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetTimeLogById(Guid id)
     {
@@ -37,6 +60,11 @@ public class TimeLogsController : ControllerBase
         return timeLog != null ? Ok(timeLog) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves all time log entries associated with a specific to-do item.
+    /// </summary>
+    /// <param name="toDoId">The unique identifier of the to-do item.</param>
+    /// <returns>200 OK with a list of <see cref="TimeLog"/> entries for the given to-do.</returns>
     [HttpGet("GetByToDoId/{toDoId}")]
     public async Task<IActionResult> GetTimeLogsByToDoId(Guid toDoId)
     {
@@ -44,6 +72,12 @@ public class TimeLogsController : ControllerBase
         return Ok(timeLogs);
     }
 
+    /// <summary>
+    /// Retrieves all time log entries recorded by a specific user.
+    /// Administrators may query any user; regular users may only query their own entries.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user whose time logs to retrieve.</param>
+    /// <returns>200 OK with a list of <see cref="TimeLog"/> entries for the given user.</returns>
     [HttpGet("GetByUserId/{userId}")]
     public async Task<IActionResult> GetTimeLogsByUserId(Guid userId)
     {
@@ -51,6 +85,13 @@ public class TimeLogsController : ControllerBase
         return Ok(timeLogs);
     }
 
+    /// <summary>
+    /// Retrieves all time log entries recorded by a specific user on a specific to-do item.
+    /// Administrators may query any combination; regular users may only query their own entries.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user.</param>
+    /// <param name="toDoId">The unique identifier of the to-do item.</param>
+    /// <returns>200 OK with a list of matching <see cref="TimeLog"/> entries.</returns>
     [HttpGet("GetByUserIdAndToDoId/{userId}/{toDoId}")]
     public async Task<IActionResult> GetTimeLogsByUserIdAndToDoId(Guid userId, Guid toDoId)
     {
@@ -58,6 +99,17 @@ public class TimeLogsController : ControllerBase
         return Ok(timeLogs);
     }
 
+    /// <summary>
+    /// Creates a new time log entry recording hours spent on a to-do item.
+    /// </summary>
+    /// <param name="request">
+    /// The creation payload containing the associated to-do ID, user ID,
+    /// hours spent, log date, and an optional description.
+    /// </param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if creation fails.
+    /// </returns>
     [HttpPost("Create")]
     public async Task<IActionResult> CreateTimeLog([FromBody] TimeLogUpsertRequestDto request)
     {
@@ -75,6 +127,17 @@ public class TimeLogsController : ControllerBase
         return created ? Ok(created) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Updates an existing time log entry with the values from the supplied request payload.
+    /// Administrators may update any entry; regular users may only update their own entries.
+    /// </summary>
+    /// <param name="request">
+    /// The update payload containing the entry's identifier along with the new field values.
+    /// </param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the update fails or the caller lacks access.
+    /// </returns>
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateTimeLog([FromBody] TimeLogUpsertRequestDto request)
     {
@@ -92,6 +155,15 @@ public class TimeLogsController : ControllerBase
         return updated ? Ok(updated) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Permanently deletes a time log entry by its unique identifier.
+    /// Administrators may delete any entry; regular users may only delete their own entries.
+    /// </summary>
+    /// <param name="id">The unique identifier of the time log entry to delete.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if deletion fails or the caller lacks access.
+    /// </returns>
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteTimeLog(Guid id)
     {

--- a/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
@@ -7,6 +7,10 @@ using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
+/// <summary>
+/// Manages to-do items. All endpoints require an authenticated user.
+/// Access to other users' items is restricted to administrators.
+/// </summary>
 [Authorize]
 [ApiController]
 [Route("api/[controller]")]
@@ -14,6 +18,10 @@ public class ToDosController : ControllerBase
 {
     private readonly IToDosService _toDosService;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ToDosController"/>.
+    /// </summary>
+    /// <param name="toDosService">The service used to perform to-do CRUD operations.</param>
     public ToDosController(IToDosService toDosService)
     {
         _toDosService = toDosService;
@@ -22,6 +30,11 @@ public class ToDosController : ControllerBase
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
     private bool IsAdmin() => User.IsInRole("Admin");
 
+    /// <summary>
+    /// Retrieves every to-do item in the system regardless of the assigned user.
+    /// Restricted to administrators.
+    /// </summary>
+    /// <returns>200 OK with a list of all <see cref="ToDo"/> items.</returns>
     [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
     public async Task<IActionResult> GetAllToDos()
@@ -30,6 +43,15 @@ public class ToDosController : ControllerBase
         return Ok(toDos);
     }
 
+    /// <summary>
+    /// Retrieves a single to-do item by its unique identifier.
+    /// Administrators may access any item; regular users may only access items assigned to them.
+    /// </summary>
+    /// <param name="id">The unique identifier of the to-do item.</param>
+    /// <returns>
+    /// 200 OK with the matching <see cref="ToDo"/> on success;
+    /// 500 Internal Server Error if the item is not found or the caller lacks access.
+    /// </returns>
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetToDoById(Guid id)
     {
@@ -37,6 +59,12 @@ public class ToDosController : ControllerBase
         return toDo != null ? Ok(toDo) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves all to-do items assigned to the specified user.
+    /// Administrators may query any user; regular users may only query their own items.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user whose to-dos to retrieve.</param>
+    /// <returns>200 OK with a list of <see cref="ToDo"/> items for the given user.</returns>
     [HttpGet("GetByUserId/{userId}")]
     public async Task<IActionResult> GetToDosByUserId(Guid userId)
     {
@@ -44,6 +72,17 @@ public class ToDosController : ControllerBase
         return Ok(toDos);
     }
 
+    /// <summary>
+    /// Creates a new to-do item from the supplied request payload.
+    /// </summary>
+    /// <param name="request">
+    /// The creation payload containing the title, description, status, optional due date,
+    /// and optional assignments to a user, team, and project.
+    /// </param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if creation fails.
+    /// </returns>
     [HttpPost("Create")]
     public async Task<IActionResult> CreateToDo([FromBody] ToDoUpsertRequestDto request)
     {
@@ -65,6 +104,17 @@ public class ToDosController : ControllerBase
         return created ? Ok(created) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Updates an existing to-do item with the values from the supplied request payload.
+    /// Administrators may update any item; regular users may only update items assigned to them.
+    /// </summary>
+    /// <param name="request">
+    /// The update payload containing the item's identifier along with the new field values.
+    /// </param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the update fails or the caller lacks access.
+    /// </returns>
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateToDo([FromBody] ToDoUpsertRequestDto request)
     {
@@ -86,6 +136,15 @@ public class ToDosController : ControllerBase
         return updated ? Ok(updated) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Permanently deletes a to-do item by its unique identifier.
+    /// Administrators may delete any item; regular users may only delete items assigned to them.
+    /// </summary>
+    /// <param name="id">The unique identifier of the to-do item to delete.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if deletion fails or the caller lacks access.
+    /// </returns>
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteToDo(Guid id)
     {

--- a/ToDoTimeManager.WebApi/Controllers/UsersController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/UsersController.cs
@@ -8,12 +8,20 @@ using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
+/// <summary>
+/// Manages user accounts including registration, profile updates, role management, and deletion.
+/// Individual endpoints carry their own authorization requirements.
+/// </summary>
 [ApiController]
 [Route("api/[controller]")]
 public class UsersController : ControllerBase
 {
     private readonly IUsersService _usersService;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="UsersController"/>.
+    /// </summary>
+    /// <param name="usersService">The service used to perform user account operations.</param>
     public UsersController(IUsersService usersService)
     {
         _usersService = usersService;
@@ -22,6 +30,11 @@ public class UsersController : ControllerBase
     private Guid GetCurrentUserId() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
     private bool IsAdmin() => User.IsInRole("Admin");
 
+    /// <summary>
+    /// Retrieves all registered user accounts. Restricted to administrators.
+    /// Sensitive fields such as passwords are excluded from the response.
+    /// </summary>
+    /// <returns>200 OK with a list of <see cref="UserResponseDto"/> objects.</returns>
     [Authorize(Roles = "Admin")]
     [HttpGet("GetAll")]
     public async Task<IActionResult> GetAllUsers()
@@ -30,6 +43,15 @@ public class UsersController : ControllerBase
         return Ok(users.Select(ToUserResponseDto));
     }
 
+    /// <summary>
+    /// Retrieves a user account by its unique identifier.
+    /// Administrators may access any account; regular users may only access their own profile.
+    /// </summary>
+    /// <param name="id">The unique identifier of the user to retrieve.</param>
+    /// <returns>
+    /// 200 OK with a <see cref="UserResponseDto"/> on success;
+    /// 500 Internal Server Error if the user is not found or the caller lacks access.
+    /// </returns>
     [Authorize]
     [HttpGet("GetById/{id}")]
     public async Task<IActionResult> GetUserById(Guid id)
@@ -38,6 +60,14 @@ public class UsersController : ControllerBase
         return user != null ? Ok(ToUserResponseDto(user)) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves a user account by their username. Restricted to administrators.
+    /// </summary>
+    /// <param name="userName">The exact username to search for.</param>
+    /// <returns>
+    /// 200 OK with a <see cref="UserResponseDto"/> on success;
+    /// 500 Internal Server Error if no matching user is found.
+    /// </returns>
     [Authorize(Roles = "Admin")]
     [HttpGet("GetByUsername/{userName}")]
     public async Task<IActionResult> GetUserByUsername(string userName)
@@ -46,6 +76,14 @@ public class UsersController : ControllerBase
         return user != null ? Ok(ToUserResponseDto(user)) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves a user account by their email address. Restricted to administrators.
+    /// </summary>
+    /// <param name="email">The email address to search for.</param>
+    /// <returns>
+    /// 200 OK with a <see cref="UserResponseDto"/> on success;
+    /// 500 Internal Server Error if no matching user is found.
+    /// </returns>
     [Authorize(Roles = "Admin")]
     [HttpGet("GetByEmail/{email}")]
     public async Task<IActionResult> GetUserByEmail(string email)
@@ -54,6 +92,15 @@ public class UsersController : ControllerBase
         return user != null ? Ok(ToUserResponseDto(user)) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Retrieves a user account by a login parameter that may be either a username or email address.
+    /// Restricted to administrators.
+    /// </summary>
+    /// <param name="loginParameter">The username or email address to search for.</param>
+    /// <returns>
+    /// 200 OK with a <see cref="UserResponseDto"/> on success;
+    /// 500 Internal Server Error if no matching user is found.
+    /// </returns>
     [Authorize(Roles = "Admin")]
     [HttpGet("GetByLoginParameter/{loginParameter}")]
     public async Task<IActionResult> GetUserByLoginParameter(string loginParameter)
@@ -62,6 +109,16 @@ public class UsersController : ControllerBase
         return user != null ? Ok(ToUserResponseDto(user)) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Registers a new user account. Publicly accessible without authentication.
+    /// </summary>
+    /// <param name="request">
+    /// The registration payload containing username, email, password, and the desired role.
+    /// </param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if registration fails.
+    /// </returns>
     [AllowAnonymous]
     [HttpPost("Create")]
     public async Task<IActionResult> CreateUser([FromBody] CreateUserRequestDto request)
@@ -70,6 +127,15 @@ public class UsersController : ControllerBase
         return created ? Ok(created) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Updates the profile of the currently authenticated user.
+    /// Users may only update their own profile.
+    /// </summary>
+    /// <param name="request">The update payload containing the new username, email, and optional password.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the update fails.
+    /// </returns>
     [Authorize]
     [HttpPut("Update")]
     public async Task<IActionResult> UpdateUser([FromBody] UpdateUserRequestDto request)
@@ -78,6 +144,15 @@ public class UsersController : ControllerBase
         return result ? Ok(result) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Changes the role assigned to a user account. Restricted to administrators.
+    /// </summary>
+    /// <param name="id">The unique identifier of the user whose role is to be changed.</param>
+    /// <param name="request">The payload specifying the new <see cref="UserRole"/> to assign.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if the operation fails.
+    /// </returns>
     [Authorize(Roles = "Admin")]
     [HttpPut("ChangeRole/{id}")]
     public async Task<IActionResult> ChangeUserRole(Guid id, [FromBody] ChangeUserRoleRequestDto request)
@@ -86,6 +161,14 @@ public class UsersController : ControllerBase
         return changed ? Ok(changed) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Permanently deletes a user account by its unique identifier. Restricted to administrators.
+    /// </summary>
+    /// <param name="id">The unique identifier of the user to delete.</param>
+    /// <returns>
+    /// 200 OK with <c>true</c> on success;
+    /// 500 Internal Server Error if deletion fails.
+    /// </returns>
     [Authorize(Roles = "Admin")]
     [HttpDelete("Delete/{id}")]
     public async Task<IActionResult> DeleteUser(Guid id)


### PR DESCRIPTION
Adds complete <summary>, <param>, and <returns> XML doc comments to every
public constructor and action method across all seven API controllers
(Auth, ToDos, TimeLogs, Users, Projects, Teams, Statistic). Documents
authorization requirements, access-control rules (admin vs. own-resource),
request payloads, and HTTP response semantics.

https://claude.ai/code/session_01JArgvpZQxjcyCeftZJTWL3