### PR TITLE
Implement two-factor authentication (2FA) via email

### DIFF
--- a/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_DeleteByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_DeleteByUserId.sql
@@ -1,4 +1,6 @@
 CREATE PROCEDURE [dbo].[sp_TwoFactorCodes_DeleteByUserId] @UserId UNIQUEIDENTIFIER
 AS
+BEGIN
     SET NOCOUNT ON;
     DELETE FROM [dbo].[TwoFactorCodes] WHERE UserId = @UserId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_DeleteByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_DeleteByUserId.sql
@@ -1,0 +1,4 @@
+CREATE PROCEDURE [dbo].[sp_TwoFactorCodes_DeleteByUserId] @UserId UNIQUEIDENTIFIER
+AS
+    SET NOCOUNT ON;
+    DELETE FROM [dbo].[TwoFactorCodes] WHERE UserId = @UserId;

--- a/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_GetByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_GetByUserId.sql
@@ -1,6 +1,8 @@
 CREATE PROCEDURE [dbo].[sp_TwoFactorCodes_GetByUserId] @UserId UNIQUEIDENTIFIER
 AS
+BEGIN
     SET NOCOUNT ON;
     SELECT Id, UserId, Code, ExpiresAt
     FROM [dbo].[TwoFactorCodes]
     WHERE UserId = @UserId;
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_GetByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_GetByUserId.sql
@@ -1,0 +1,6 @@
+CREATE PROCEDURE [dbo].[sp_TwoFactorCodes_GetByUserId] @UserId UNIQUEIDENTIFIER
+AS
+    SET NOCOUNT ON;
+    SELECT Id, UserId, Code, ExpiresAt
+    FROM [dbo].[TwoFactorCodes]
+    WHERE UserId = @UserId;

--- a/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_Upsert.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_Upsert.sql
@@ -1,0 +1,9 @@
+CREATE PROCEDURE [dbo].[sp_TwoFactorCodes_Upsert] @Id        UNIQUEIDENTIFIER,
+                                                  @UserId    UNIQUEIDENTIFIER,
+                                                  @Code      NVARCHAR(7),
+                                                  @ExpiresAt DATETIME
+AS
+    SET NOCOUNT ON;
+    DELETE FROM [dbo].[TwoFactorCodes] WHERE UserId = @UserId;
+    INSERT INTO [dbo].[TwoFactorCodes] (Id, UserId, Code, ExpiresAt)
+    VALUES (@Id, @UserId, @Code, @ExpiresAt);

--- a/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_Upsert.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_Upsert.sql
@@ -3,7 +3,14 @@ CREATE PROCEDURE [dbo].[sp_TwoFactorCodes_Upsert] @Id        UNIQUEIDENTIFIER,
                                                   @Code      NVARCHAR(7),
                                                   @ExpiresAt DATETIME
 AS
-    SET NOCOUNT ON;
-    EXEC [dbo].[sp_TwoFactorCodes_DeleteByUserId] @UserId;
-    INSERT INTO [dbo].[TwoFactorCodes] (Id, UserId, Code, ExpiresAt)
-    VALUES (@Id, @UserId, @Code, @ExpiresAt);
+    BEGIN TRANSACTION;
+    BEGIN TRY
+        EXEC [dbo].[sp_TwoFactorCodes_DeleteByUserId] @UserId;
+        INSERT INTO [dbo].[TwoFactorCodes] (Id, UserId, Code, ExpiresAt)
+        VALUES (@Id, @UserId, @Code, @ExpiresAt);
+        COMMIT TRANSACTION;
+    END TRY
+    BEGIN CATCH
+        ROLLBACK TRANSACTION;
+        THROW;
+    END CATCH

--- a/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_Upsert.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/TwoFactorCodes/sp_TwoFactorCodes_Upsert.sql
@@ -4,6 +4,6 @@ CREATE PROCEDURE [dbo].[sp_TwoFactorCodes_Upsert] @Id        UNIQUEIDENTIFIER,
                                                   @ExpiresAt DATETIME
 AS
     SET NOCOUNT ON;
-    DELETE FROM [dbo].[TwoFactorCodes] WHERE UserId = @UserId;
+    EXEC [dbo].[sp_TwoFactorCodes_DeleteByUserId] @UserId;
     INSERT INTO [dbo].[TwoFactorCodes] (Id, UserId, Code, ExpiresAt)
     VALUES (@Id, @UserId, @Code, @ExpiresAt);

--- a/ToDoTimeManager.DataBase/Tables/TwoFactorCodes.sql
+++ b/ToDoTimeManager.DataBase/Tables/TwoFactorCodes.sql
@@ -1,0 +1,8 @@
+CREATE TABLE [dbo].[TwoFactorCodes]
+(
+    Id        UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID() PRIMARY KEY,
+    UserId    UNIQUEIDENTIFIER NOT NULL REFERENCES [dbo].[Users] (Id) ON DELETE CASCADE,
+    Code      NVARCHAR(7)      NOT NULL,
+    ExpiresAt DATETIME         NOT NULL,
+    CONSTRAINT [UQ_TwoFactorCodes_UserId] UNIQUE (UserId)
+)

--- a/ToDoTimeManager.DataBase/ToDoTimeManager.DataBase.sqlproj
+++ b/ToDoTimeManager.DataBase/ToDoTimeManager.DataBase.sqlproj
@@ -65,6 +65,7 @@
     <Folder Include="StoredProcedures\TeamMembers" />
     <Folder Include="StoredProcedures\Projects" />
     <Folder Include="StoredProcedures\ProjectTeams" />
+    <Folder Include="StoredProcedures\TwoFactorCodes" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="Tables\Users.sql" />
@@ -122,5 +123,9 @@
     <Build Include="StoredProcedures\ProjectTeams\sp_ProjectTeams_GetByProjectId.sql" />
     <Build Include="StoredProcedures\ProjectTeams\sp_ProjectTeams_GetByProjectIdAndTeamId.sql" />
     <Build Include="StoredProcedures\ProjectTeams\sp_ProjectTeams_DeleteByProjectIdAndTeamId.sql" />
+    <Build Include="Tables\TwoFactorCodes.sql" />
+    <Build Include="StoredProcedures\TwoFactorCodes\sp_TwoFactorCodes_DeleteByUserId.sql" />
+    <Build Include="StoredProcedures\TwoFactorCodes\sp_TwoFactorCodes_GetByUserId.sql" />
+    <Build Include="StoredProcedures\TwoFactorCodes\sp_TwoFactorCodes_Upsert.sql" />
   </ItemGroup>
 </Project>

--- a/ToDoTimeManager.Shared/DTOs/SendTwoFactorCodeRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/SendTwoFactorCodeRequestDto.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public class SendTwoFactorCodeRequestDto
+{
+    [Required]
+    public Guid UserId { get; set; }
+}

--- a/ToDoTimeManager.Shared/DTOs/SendTwoFactorCodeRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/SendTwoFactorCodeRequestDto.cs
@@ -1,9 +1,9 @@
-using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Utils;
 
 namespace ToDoTimeManager.Shared.DTOs;
 
 public class SendTwoFactorCodeRequestDto
 {
-    [Required]
+    [NotEmptyGuid]
     public Guid UserId { get; set; }
 }

--- a/ToDoTimeManager.Shared/DTOs/VerifyTwoFactorRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/VerifyTwoFactorRequestDto.cs
@@ -1,10 +1,11 @@
 using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Utils;
 
 namespace ToDoTimeManager.Shared.DTOs;
 
 public class VerifyTwoFactorRequestDto
 {
-    [Required]
+    [NotEmptyGuid]
     public Guid UserId { get; set; }
 
     [Required]

--- a/ToDoTimeManager.Shared/DTOs/VerifyTwoFactorRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/VerifyTwoFactorRequestDto.cs
@@ -9,5 +9,6 @@ public class VerifyTwoFactorRequestDto
     public Guid UserId { get; set; }
 
     [Required]
-    public string? Code { get; set; }
+    [RegularExpression(@"^\d{3}-\d{3}$", ErrorMessage = "Code must be in the format XXX-XXX.")]
+    public string Code { get; set; } = string.Empty;
 }

--- a/ToDoTimeManager.Shared/DTOs/VerifyTwoFactorRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/VerifyTwoFactorRequestDto.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ToDoTimeManager.Shared.DTOs;
+
+public class VerifyTwoFactorRequestDto
+{
+    [Required]
+    public Guid UserId { get; set; }
+
+    [Required]
+    public string? Code { get; set; }
+}

--- a/ToDoTimeManager.Shared/Models/TwoFactorPendingModel.cs
+++ b/ToDoTimeManager.Shared/Models/TwoFactorPendingModel.cs
@@ -1,0 +1,7 @@
+namespace ToDoTimeManager.Shared.Models;
+
+public class TwoFactorPendingModel
+{
+    public Guid UserId { get; set; }
+    public string? MaskedEmail { get; set; }
+}

--- a/ToDoTimeManager.WebApi/Controllers/AuthController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/AuthController.cs
@@ -1,51 +1,61 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using ToDoTimeManager.Shared.DTOs;
 using ToDoTimeManager.Shared.Models;
 using ToDoTimeManager.WebApi.Services.Interfaces;
 
 namespace ToDoTimeManager.WebApi.Controllers;
 
 /// <summary>
-/// Handles authentication operations including login and token refresh.
+/// Handles authentication operations including login, 2FA code verification, and token refresh.
 /// All endpoints are publicly accessible without a prior authentication token.
 /// </summary>
 [AllowAnonymous]
 public class AuthController : BaseController
 {
     private readonly IAuthService _authService;
+    private readonly ITwoFactorService _twoFactorService;
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="AuthController"/>.
-    /// </summary>
-    /// <param name="authService">The authentication service used to validate credentials and issue tokens.</param>
-    public AuthController(IAuthService authService)
+    public AuthController(IAuthService authService, ITwoFactorService twoFactorService)
     {
         _authService = authService;
+        _twoFactorService = twoFactorService;
     }
 
     /// <summary>
-    /// Authenticates a user with their credentials and returns a JWT access token paired with a refresh token.
+    /// Validates credentials and sends a 2FA code to the user's email.
+    /// The token is NOT returned here — call VerifyCode after entering the code.
     /// </summary>
-    /// <param name="loginUser">The login credentials containing a username or email and a password.</param>
-    /// <returns>
-    /// 200 OK with a <see cref="TokenModel"/> containing the access and refresh tokens on success;
-    /// 500 Internal Server Error if authentication fails.
-    /// </returns>
     [HttpPost("Login")]
     public async Task<IActionResult> Login(LoginUser? loginUser)
     {
-        var tokenModel = await _authService.Login(loginUser!);
-        return tokenModel != null ? Ok(tokenModel) : StatusCode(500);
+        var pending = await _authService.Login(loginUser!);
+        return pending != null ? Ok(pending) : StatusCode(500);
+    }
+
+    /// <summary>
+    /// Resends a 2FA code to the user's email (e.g. when the previous one expired).
+    /// </summary>
+    [HttpPost("SendCode")]
+    public async Task<IActionResult> SendCode([FromBody] SendTwoFactorCodeRequestDto request)
+    {
+        var pending = await _twoFactorService.SendCode(request.UserId);
+        return Ok(pending);
+    }
+
+    /// <summary>
+    /// Verifies the 2FA code and returns a JWT access token + refresh token on success.
+    /// </summary>
+    [HttpPost("VerifyCode")]
+    public async Task<IActionResult> VerifyCode([FromBody] VerifyTwoFactorRequestDto request)
+    {
+        var tokenModel = await _twoFactorService.VerifyCode(request.UserId, request.Code!);
+        return Ok(tokenModel);
     }
 
     /// <summary>
     /// Issues a new access token using a valid, non-expired refresh token.
     /// </summary>
-    /// <param name="tokenModel">The current token pair containing the refresh token to exchange.</param>
-    /// <returns>
-    /// 200 OK with a refreshed <see cref="TokenModel"/> on success;
-    /// 500 Internal Server Error if the refresh token is invalid or expired.
-    /// </returns>
     [HttpPost("RefreshToken")]
     public IActionResult RefreshToken(TokenModel? tokenModel)
     {

--- a/ToDoTimeManager.WebApi/Controllers/AuthController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/AuthController.cs
@@ -7,7 +7,7 @@ using ToDoTimeManager.WebApi.Services.Interfaces;
 namespace ToDoTimeManager.WebApi.Controllers;
 
 /// <summary>
-/// Handles authentication operations including login, 2FA code verification, and token refresh.
+/// Handles authentication operations including login, two-factor code management, and token refresh.
 /// All endpoints are publicly accessible without a prior authentication token.
 /// </summary>
 [AllowAnonymous]
@@ -16,6 +16,11 @@ public class AuthController : BaseController
     private readonly IAuthService _authService;
     private readonly ITwoFactorService _twoFactorService;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="AuthController"/>.
+    /// </summary>
+    /// <param name="authService">The authentication service used to validate credentials.</param>
+    /// <param name="twoFactorService">The two-factor authentication service used to manage verification codes and issue tokens.</param>
     public AuthController(IAuthService authService, ITwoFactorService twoFactorService)
     {
         _authService = authService;
@@ -23,9 +28,14 @@ public class AuthController : BaseController
     }
 
     /// <summary>
-    /// Validates credentials and sends a 2FA code to the user's email.
-    /// The token is NOT returned here — call VerifyCode after entering the code.
+    /// Validates the user's credentials and sends a two-factor verification code to their registered email address.
+    /// The JWT token is <b>not</b> returned at this step — the client must call <c>VerifyCode</c> to complete authentication.
     /// </summary>
+    /// <param name="loginUser">The login credentials containing a username or email and a password.</param>
+    /// <returns>
+    /// 200 OK with a <see cref="TwoFactorPendingModel"/> containing the user ID and masked email address on success;
+    /// 500 Internal Server Error if authentication fails unexpectedly.
+    /// </returns>
     [HttpPost("Login")]
     public async Task<IActionResult> Login(LoginUser? loginUser)
     {
@@ -34,8 +44,13 @@ public class AuthController : BaseController
     }
 
     /// <summary>
-    /// Resends a 2FA code to the user's email (e.g. when the previous one expired).
+    /// Generates a new two-factor verification code and sends it to the user's registered email address.
+    /// Use this endpoint to resend a code when the previous one has expired or was not received.
     /// </summary>
+    /// <param name="request">The request containing the user ID for which to send the code.</param>
+    /// <returns>
+    /// 200 OK with a <see cref="TwoFactorPendingModel"/> containing the user ID and masked email address.
+    /// </returns>
     [HttpPost("SendCode")]
     public async Task<IActionResult> SendCode([FromBody] SendTwoFactorCodeRequestDto request)
     {
@@ -44,8 +59,14 @@ public class AuthController : BaseController
     }
 
     /// <summary>
-    /// Verifies the 2FA code and returns a JWT access token + refresh token on success.
+    /// Verifies the two-factor code submitted by the user and, upon success, issues a JWT access token
+    /// paired with a refresh token. The code is invalidated immediately after use.
     /// </summary>
+    /// <param name="request">The request containing the user ID and the verification code.</param>
+    /// <returns>
+    /// 200 OK with a <see cref="TokenModel"/> containing the access token, refresh token, and refresh token expiry on success;
+    /// 400 Bad Request if the code is invalid or has expired.
+    /// </returns>
     [HttpPost("VerifyCode")]
     public async Task<IActionResult> VerifyCode([FromBody] VerifyTwoFactorRequestDto request)
     {
@@ -55,7 +76,13 @@ public class AuthController : BaseController
 
     /// <summary>
     /// Issues a new access token using a valid, non-expired refresh token.
+    /// The refresh token itself is not rotated — the same refresh token and its expiry are preserved.
     /// </summary>
+    /// <param name="tokenModel">The current token pair containing the refresh token to exchange.</param>
+    /// <returns>
+    /// 200 OK with a refreshed <see cref="TokenModel"/> on success;
+    /// 500 Internal Server Error if the refresh token is invalid or expired.
+    /// </returns>
     [HttpPost("RefreshToken")]
     public IActionResult RefreshToken(TokenModel? tokenModel)
     {

--- a/ToDoTimeManager.WebApi/Entities/TwoFactorCodeEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/TwoFactorCodeEntity.cs
@@ -1,0 +1,9 @@
+namespace ToDoTimeManager.WebApi.Entities;
+
+public class TwoFactorCodeEntity
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public DateTime ExpiresAt { get; set; }
+}

--- a/ToDoTimeManager.WebApi/Program.cs
+++ b/ToDoTimeManager.WebApi/Program.cs
@@ -48,6 +48,11 @@ public class Program
         builder.Services.AddScoped<IStatisticService, StatisticService>();
         builder.Services.AddScoped<ITeamsService, TeamsService>();
         builder.Services.AddScoped<IProjectsService, ProjectsService>();
+        builder.Services.AddScoped<ITwoFactorService, TwoFactorService>();
+
+        builder.Services.AddScoped<ITwoFactorCodesDataController, TwoFactorCodesDataController>();
+        builder.Services.AddScoped<ITwoFactorCodeGeneratorService, TwoFactorCodeGeneratorService>();
+        builder.Services.AddScoped<IEmailService, EmailService>();
 
         builder.Services.AddScoped<GlobalExceptionHandler>();
 

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/TwoFactorCodesDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Implementation/TwoFactorCodesDataController.cs
@@ -1,0 +1,60 @@
+using Dapper;
+using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Services.DataControllers.DbAccessServices;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Implementation;
+
+public class TwoFactorCodesDataController : ITwoFactorCodesDataController
+{
+    private readonly IDbAccessService _dbAccessService;
+    private readonly ILogger<TwoFactorCodesDataController> _logger;
+
+    public TwoFactorCodesDataController(IDbAccessService dbAccessService, ILogger<TwoFactorCodesDataController> logger)
+    {
+        _dbAccessService = dbAccessService;
+        _logger = logger;
+    }
+
+    public async Task<bool> UpsertCode(TwoFactorCodeEntity entity)
+    {
+        try
+        {
+            return await _dbAccessService.AddRecord("sp_TwoFactorCodes_Upsert", entity) >= 1;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
+    }
+
+    public async Task<TwoFactorCodeEntity?> GetByUserId(Guid userId)
+    {
+        try
+        {
+            return await _dbAccessService.GetOneByParameter<TwoFactorCodeEntity>(
+                "sp_TwoFactorCodes_GetByUserId", "UserId", userId);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return null;
+        }
+    }
+
+    public async Task<bool> DeleteByUserId(Guid userId)
+    {
+        try
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("UserId", userId);
+            return await _dbAccessService.ExecuteByParameters("sp_TwoFactorCodes_DeleteByUserId", parameters) >= 1;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return false;
+        }
+    }
+}

--- a/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/ITwoFactorCodesDataController.cs
+++ b/ToDoTimeManager.WebApi/Services/DataControllers/Interfaces/ITwoFactorCodesDataController.cs
@@ -1,0 +1,10 @@
+using ToDoTimeManager.WebApi.Entities;
+
+namespace ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+
+public interface ITwoFactorCodesDataController
+{
+    Task<bool> UpsertCode(TwoFactorCodeEntity entity);
+    Task<TwoFactorCodeEntity?> GetByUserId(Guid userId);
+    Task<bool> DeleteByUserId(Guid userId);
+}

--- a/ToDoTimeManager.WebApi/Services/Implementations/AuthService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/AuthService.cs
@@ -18,22 +18,25 @@ public class AuthService : IAuthService
     private readonly IJwtGeneratorService _jwtGeneratorService;
     private readonly IConfiguration _configuration;
     private readonly IUsersDataController _usersDataController;
+    private readonly ITwoFactorService _twoFactorService;
 
     public AuthService(
         ILogger<AuthService> logger,
         IPasswordHelperService passwordHelperService,
         IJwtGeneratorService jwtGeneratorService,
         IConfiguration configuration,
-        IUsersDataController usersDataController)
+        IUsersDataController usersDataController,
+        ITwoFactorService twoFactorService)
     {
         _logger = logger;
         _passwordHelperService = passwordHelperService;
         _jwtGeneratorService = jwtGeneratorService;
         _configuration = configuration;
         _usersDataController = usersDataController;
+        _twoFactorService = twoFactorService;
     }
 
-    public async Task<TokenModel?> Login(LoginUser loginUser)
+    public async Task<TwoFactorPendingModel?> Login(LoginUser loginUser)
     {
         if (loginUser == null || string.IsNullOrWhiteSpace(loginUser.LoginParameter))
             throw new ValidationException("Login data is invalid");
@@ -51,13 +54,7 @@ public class AuthService : IAuthService
             if (!_passwordHelperService.VerifyPassword(user, passwordHash))
                 throw new ValidationException("Invalid username or password");
 
-            return new TokenModel
-            {
-                AccessToken = _jwtGeneratorService.GenerateAccessToken(user.Id.ToString(), user.UserRole),
-                RefreshToken = _jwtGeneratorService.GenerateRefreshToken(),
-                RefreshTokenExpiresAt =
-                    DateTime.UtcNow.AddDays(int.Parse(_configuration["JwtSettings:RefreshTokenLifetime"] ?? "7"))
-            };
+            return await _twoFactorService.SendCode(user.Id);
         }
         catch (ServiceException)
         {

--- a/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
@@ -67,7 +67,10 @@ public class TwoFactorService : ITwoFactorService
     {
         var record = await _twoFactorCodesDataController.GetByUserId(userId);
         if (record == null)
-            throw new ValidationException("No verification code found. Please request a new one.");
+        {
+            _logger.LogError("Unable to verify two-factor code for user {UserId}: code lookup returned null.", userId);
+            throw new InvalidOperationException("Unable to verify the verification code at this time.");
+        }
 
         if (record.ExpiresAt < DateTime.UtcNow)
         {

--- a/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
@@ -51,7 +51,9 @@ public class TwoFactorService : ITwoFactorService
                 int.Parse(_configuration["TwoFactorSettings:CodeLifetimeMinutes"] ?? "5"))
         };
 
-        await _twoFactorCodesDataController.UpsertCode(entity);
+        var upsertSucceeded = await _twoFactorCodesDataController.UpsertCode(entity);
+        if (!upsertSucceeded)
+            throw new ServiceException("Failed to persist verification code.");
         await _emailService.SendTwoFactorCodeAsync(userEntity.Email!, code);
 
         return new TwoFactorPendingModel

--- a/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
@@ -1,0 +1,100 @@
+using ToDoTimeManager.Shared.Models;
+using ToDoTimeManager.WebApi.Entities;
+using ToDoTimeManager.WebApi.Exceptions;
+using ToDoTimeManager.WebApi.Services.DataControllers.Interfaces;
+using ToDoTimeManager.WebApi.Services.Interfaces;
+using ToDoTimeManager.WebApi.Utils.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.Implementations;
+
+public class TwoFactorService : ITwoFactorService
+{
+    private readonly ITwoFactorCodesDataController _twoFactorCodesDataController;
+    private readonly IUsersDataController _usersDataController;
+    private readonly ITwoFactorCodeGeneratorService _codeGeneratorService;
+    private readonly IEmailService _emailService;
+    private readonly IJwtGeneratorService _jwtGeneratorService;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<TwoFactorService> _logger;
+
+    public TwoFactorService(
+        ITwoFactorCodesDataController twoFactorCodesDataController,
+        IUsersDataController usersDataController,
+        ITwoFactorCodeGeneratorService codeGeneratorService,
+        IEmailService emailService,
+        IJwtGeneratorService jwtGeneratorService,
+        IConfiguration configuration,
+        ILogger<TwoFactorService> logger)
+    {
+        _twoFactorCodesDataController = twoFactorCodesDataController;
+        _usersDataController = usersDataController;
+        _codeGeneratorService = codeGeneratorService;
+        _emailService = emailService;
+        _jwtGeneratorService = jwtGeneratorService;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<TwoFactorPendingModel> SendCode(Guid userId)
+    {
+        var userEntity = await _usersDataController.GetUserById(userId);
+        if (userEntity == null)
+            throw new NotFoundException("User not found");
+
+        var code = _codeGeneratorService.GenerateCode();
+        var entity = new TwoFactorCodeEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Code = code,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(5)
+        };
+
+        await _twoFactorCodesDataController.UpsertCode(entity);
+        await _emailService.SendTwoFactorCodeAsync(userEntity.Email!, code);
+
+        return new TwoFactorPendingModel
+        {
+            UserId = userId,
+            MaskedEmail = MaskEmail(userEntity.Email!)
+        };
+    }
+
+    public async Task<TokenModel> VerifyCode(Guid userId, string code)
+    {
+        var record = await _twoFactorCodesDataController.GetByUserId(userId);
+        if (record == null)
+            throw new ValidationException("No verification code found. Please request a new one.");
+
+        if (record.ExpiresAt < DateTime.UtcNow)
+        {
+            await _twoFactorCodesDataController.DeleteByUserId(userId);
+            throw new ValidationException("Verification code has expired. Please request a new one.");
+        }
+
+        if (!string.Equals(record.Code, code, StringComparison.OrdinalIgnoreCase))
+            throw new ValidationException("Invalid verification code.");
+
+        await _twoFactorCodesDataController.DeleteByUserId(userId);
+
+        var userEntity = await _usersDataController.GetUserById(userId);
+        if (userEntity == null)
+            throw new NotFoundException("User not found");
+
+        var user = userEntity.ToUser();
+        return new TokenModel
+        {
+            AccessToken = _jwtGeneratorService.GenerateAccessToken(user.Id.ToString(), user.UserRole),
+            RefreshToken = _jwtGeneratorService.GenerateRefreshToken(),
+            RefreshTokenExpiresAt =
+                DateTime.UtcNow.AddDays(int.Parse(_configuration["JwtSettings:RefreshTokenLifetime"] ?? "7"))
+        };
+    }
+
+    private static string MaskEmail(string email)
+    {
+        var atIndex = email.IndexOf('@');
+        if (atIndex <= 1) return email;
+        return $"{email[0]}***{email[atIndex..]}";
+    }
+}

--- a/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
@@ -41,6 +41,9 @@ public class TwoFactorService : ITwoFactorService
         if (userEntity == null)
             throw new NotFoundException("User not found");
 
+        if (string.IsNullOrWhiteSpace(userEntity.Email))
+            throw new ValidationException("User has no email address configured.");
+
         var code = _codeGeneratorService.GenerateCode();
         var entity = new TwoFactorCodeEntity
         {
@@ -54,12 +57,12 @@ public class TwoFactorService : ITwoFactorService
         var upsertSucceeded = await _twoFactorCodesDataController.UpsertCode(entity);
         if (!upsertSucceeded)
             throw new ServiceException("Failed to persist verification code.");
-        await _emailService.SendTwoFactorCodeAsync(userEntity.Email!, code);
+        await _emailService.SendTwoFactorCodeAsync(userEntity.Email, code);
 
         return new TwoFactorPendingModel
         {
             UserId = userId,
-            MaskedEmail = MaskEmail(userEntity.Email!)
+            MaskedEmail = MaskEmail(userEntity.Email)
         };
     }
 
@@ -81,7 +84,9 @@ public class TwoFactorService : ITwoFactorService
         if (!string.Equals(record.Code, code, StringComparison.OrdinalIgnoreCase))
             throw new ValidationException("Invalid verification code.");
 
-        await _twoFactorCodesDataController.DeleteByUserId(userId);
+        var deleted = await _twoFactorCodesDataController.DeleteByUserId(userId);
+        if (!deleted)
+            throw new ServiceException("Failed to invalidate verification code. Please try again.");
 
         var userEntity = await _usersDataController.GetUserById(userId);
         if (userEntity == null)

--- a/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/TwoFactorService.cs
@@ -47,7 +47,8 @@ public class TwoFactorService : ITwoFactorService
             Id = Guid.NewGuid(),
             UserId = userId,
             Code = code,
-            ExpiresAt = DateTime.UtcNow.AddMinutes(5)
+            ExpiresAt = DateTime.UtcNow.AddMinutes(
+                int.Parse(_configuration["TwoFactorSettings:CodeLifetimeMinutes"] ?? "5"))
         };
 
         await _twoFactorCodesDataController.UpsertCode(entity);

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IAuthService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IAuthService.cs
@@ -4,6 +4,6 @@ namespace ToDoTimeManager.WebApi.Services.Interfaces;
 
 public interface IAuthService
 {
-    Task<TokenModel?> Login(LoginUser loginUser);
+    Task<TwoFactorPendingModel?> Login(LoginUser loginUser);
     TokenModel? RefreshAuthToken(TokenModel tokenModel);
 }

--- a/ToDoTimeManager.WebApi/Services/Interfaces/ITwoFactorService.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/ITwoFactorService.cs
@@ -1,0 +1,9 @@
+using ToDoTimeManager.Shared.Models;
+
+namespace ToDoTimeManager.WebApi.Services.Interfaces;
+
+public interface ITwoFactorService
+{
+    Task<TwoFactorPendingModel> SendCode(Guid userId);
+    Task<TokenModel> VerifyCode(Guid userId, string code);
+}

--- a/ToDoTimeManager.WebApi/ToDoTimeManager.WebApi.csproj
+++ b/ToDoTimeManager.WebApi/ToDoTimeManager.WebApi.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.21" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+    <PackageReference Include="MailKit" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ToDoTimeManager.WebApi/Utils/Implementations/EmailService.cs
+++ b/ToDoTimeManager.WebApi/Utils/Implementations/EmailService.cs
@@ -1,0 +1,41 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using ToDoTimeManager.WebApi.Utils.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Utils.Implementations;
+
+public class EmailService : IEmailService
+{
+    private readonly IConfiguration _configuration;
+
+    public EmailService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public async Task SendTwoFactorCodeAsync(string toEmail, string code)
+    {
+        var settings = _configuration.GetSection("EmailSettings");
+        var host = settings["Host"]!;
+        var port = int.Parse(settings["Port"]!);
+        var senderEmail = settings["SenderEmail"]!;
+        var senderName = settings["SenderName"]!;
+        var password = settings["Password"]!;
+
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress(senderName, senderEmail));
+        message.To.Add(MailboxAddress.Parse(toEmail));
+        message.Subject = "Your verification code";
+        message.Body = new TextPart("plain")
+        {
+            Text = $"Your verification code: {code}\n\nThis code expires in 5 minutes."
+        };
+
+        using var client = new SmtpClient();
+        await client.ConnectAsync(host, port, SecureSocketOptions.StartTls);
+        await client.AuthenticateAsync(senderEmail, password);
+        await client.SendAsync(message);
+        await client.DisconnectAsync(true);
+    }
+}

--- a/ToDoTimeManager.WebApi/Utils/Implementations/EmailService.cs
+++ b/ToDoTimeManager.WebApi/Utils/Implementations/EmailService.cs
@@ -23,14 +23,80 @@ public class EmailService : IEmailService
         var senderName = settings["SenderName"]!;
         var password = settings["Password"]!;
 
+        var lifetimeMinutes = _configuration["TwoFactorSettings:CodeLifetimeMinutes"] ?? "5";
+
         var message = new MimeMessage();
         message.From.Add(new MailboxAddress(senderName, senderEmail));
         message.To.Add(MailboxAddress.Parse(toEmail));
-        message.Subject = "Your verification code";
-        message.Body = new TextPart("plain")
+        message.Subject = "Your verification code — ToDoTimeManager";
+
+        var bodyBuilder = new BodyBuilder
         {
-            Text = $"Your verification code: {code}\n\nThis code expires in 5 minutes."
+            HtmlBody = $"""
+                <!DOCTYPE html>
+                <html lang="en">
+                <head>
+                  <meta charset="UTF-8" />
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                  <title>Verification Code</title>
+                </head>
+                <body style="margin:0;padding:0;background-color:#f4f6f8;font-family:Arial,Helvetica,sans-serif;">
+                  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f6f8;padding:40px 0;">
+                    <tr>
+                      <td align="center">
+                        <table width="520" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+                          <!-- Header -->
+                          <tr>
+                            <td style="background-color:#4f46e5;padding:32px 40px;text-align:center;">
+                              <h1 style="margin:0;color:#ffffff;font-size:22px;font-weight:700;letter-spacing:0.5px;">
+                                ToDoTimeManager
+                              </h1>
+                            </td>
+                          </tr>
+                          <!-- Body -->
+                          <tr>
+                            <td style="padding:40px 40px 24px;">
+                              <p style="margin:0 0 8px;font-size:16px;color:#374151;font-weight:600;">
+                                Two-Factor Verification
+                              </p>
+                              <p style="margin:0 0 24px;font-size:14px;color:#6b7280;line-height:1.6;">
+                                Use the code below to complete your sign-in. It is valid for
+                                <strong>{lifetimeMinutes} minutes</strong> and can only be used once.
+                              </p>
+                              <!-- Code box -->
+                              <table width="100%" cellpadding="0" cellspacing="0">
+                                <tr>
+                                  <td align="center" style="background-color:#f0f0ff;border:2px dashed #4f46e5;border-radius:8px;padding:24px;">
+                                    <span style="font-size:36px;font-weight:700;letter-spacing:8px;color:#4f46e5;font-family:'Courier New',monospace;">
+                                      {code}
+                                    </span>
+                                  </td>
+                                </tr>
+                              </table>
+                              <p style="margin:24px 0 0;font-size:13px;color:#9ca3af;line-height:1.5;">
+                                If you did not request this code, you can safely ignore this email.
+                                Someone may have entered your email by mistake.
+                              </p>
+                            </td>
+                          </tr>
+                          <!-- Footer -->
+                          <tr>
+                            <td style="padding:16px 40px 32px;text-align:center;border-top:1px solid #f3f4f6;">
+                              <p style="margin:0;font-size:12px;color:#d1d5db;">
+                                &copy; {DateTime.UtcNow.Year} ToDoTimeManager. All rights reserved.
+                              </p>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </body>
+                </html>
+                """
         };
+
+        message.Body = bodyBuilder.ToMessageBody();
 
         using var client = new SmtpClient();
         await client.ConnectAsync(host, port, SecureSocketOptions.StartTls);

--- a/ToDoTimeManager.WebApi/Utils/Implementations/EmailService.cs
+++ b/ToDoTimeManager.WebApi/Utils/Implementations/EmailService.cs
@@ -98,10 +98,11 @@ public class EmailService : IEmailService
 
         message.Body = bodyBuilder.ToMessageBody();
 
+        using var cancellationTokenSource = new System.Threading.CancellationTokenSource(System.TimeSpan.FromSeconds(30));
         using var client = new SmtpClient();
-        await client.ConnectAsync(host, port, SecureSocketOptions.StartTls);
-        await client.AuthenticateAsync(senderEmail, password);
-        await client.SendAsync(message);
-        await client.DisconnectAsync(true);
+        await client.ConnectAsync(host, port, SecureSocketOptions.StartTls, cancellationTokenSource.Token);
+        await client.AuthenticateAsync(senderEmail, password, cancellationTokenSource.Token);
+        await client.SendAsync(message, cancellationTokenSource.Token);
+        await client.DisconnectAsync(true, cancellationTokenSource.Token);
     }
 }

--- a/ToDoTimeManager.WebApi/Utils/Implementations/TwoFactorCodeGeneratorService.cs
+++ b/ToDoTimeManager.WebApi/Utils/Implementations/TwoFactorCodeGeneratorService.cs
@@ -1,0 +1,18 @@
+using System.Security.Cryptography;
+using ToDoTimeManager.WebApi.Utils.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Utils.Implementations;
+
+public class TwoFactorCodeGeneratorService : ITwoFactorCodeGeneratorService
+{
+    private const string Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    public string GenerateCode()
+    {
+        var chars = new char[6];
+        for (var i = 0; i < 6; i++)
+            chars[i] = Alphabet[RandomNumberGenerator.GetInt32(Alphabet.Length)];
+
+        return $"{chars[0]}{chars[1]}{chars[2]}-{chars[3]}{chars[4]}{chars[5]}";
+    }
+}

--- a/ToDoTimeManager.WebApi/Utils/Interfaces/IEmailService.cs
+++ b/ToDoTimeManager.WebApi/Utils/Interfaces/IEmailService.cs
@@ -1,0 +1,6 @@
+namespace ToDoTimeManager.WebApi.Utils.Interfaces;
+
+public interface IEmailService
+{
+    Task SendTwoFactorCodeAsync(string toEmail, string code);
+}

--- a/ToDoTimeManager.WebApi/Utils/Interfaces/ITwoFactorCodeGeneratorService.cs
+++ b/ToDoTimeManager.WebApi/Utils/Interfaces/ITwoFactorCodeGeneratorService.cs
@@ -1,0 +1,6 @@
+namespace ToDoTimeManager.WebApi.Utils.Interfaces;
+
+public interface ITwoFactorCodeGeneratorService
+{
+    string GenerateCode();
+}

--- a/ToDoTimeManager.WebApi/appsettings.json
+++ b/ToDoTimeManager.WebApi/appsettings.json
@@ -17,6 +17,9 @@
     }
   },
   "AllowedHosts": "*",
+  "TwoFactorSettings": {
+    "CodeLifetimeMinutes": "5"
+  },
   "EmailSettings": {
     "Host": "smtp.gmail.com",
     "Port": "587",

--- a/ToDoTimeManager.WebApi/appsettings.json
+++ b/ToDoTimeManager.WebApi/appsettings.json
@@ -16,5 +16,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "EmailSettings": {
+    "Host": "smtp.gmail.com",
+    "Port": "587",
+    "SenderEmail": "",
+    "SenderName": "ToDoTimeManager",
+    "Password": ""
+  }
 }


### PR DESCRIPTION
## Summary
This PR implements a complete two-factor authentication (2FA) system using email-based verification codes. The authentication flow now requires users to verify their identity with a code sent to their email before receiving JWT tokens.

## Key Changes

**Authentication Flow**
- Modified login endpoint to send a 2FA code instead of returning tokens immediately
- Added new `VerifyCode` endpoint to exchange a valid 2FA code for JWT tokens
- Added `SendCode` endpoint to resend codes when needed (e.g., after expiration)

**Core 2FA Services**
- `TwoFactorService`: Orchestrates code generation, validation, and token issuance
- `TwoFactorCodeGeneratorService`: Generates cryptographically secure 6-character alphanumeric codes in XXX-XXX format
- `EmailService`: Sends verification codes via SMTP (configured for Gmail)

**Data Layer**
- `TwoFactorCodesDataController`: Manages 2FA code persistence
- New `TwoFactorCodes` database table with user-scoped unique constraint
- Three stored procedures: `sp_TwoFactorCodes_Upsert`, `sp_TwoFactorCodes_GetByUserId`, `sp_TwoFactorCodes_DeleteByUserId`

**DTOs & Models**
- `TwoFactorPendingModel`: Response after successful login (contains masked email and user ID)
- `SendTwoFactorCodeRequestDto`: Request to resend a code
- `VerifyTwoFactorRequestDto`: Request to verify a code and obtain tokens

**Configuration**
- Added `EmailSettings` section to `appsettings.json` for SMTP configuration
- Registered all new services in dependency injection container
- Added MailKit NuGet package for email functionality

## Implementation Details

- Verification codes expire after 5 minutes
- Email addresses are masked in responses (e.g., `a***@example.com`) for privacy
- Code validation is case-insensitive
- Expired codes are automatically deleted from the database
- All database operations include error logging and graceful failure handling

https://claude.ai/code/session_01UwZktVoayxCxr3hudNFuTP