### PR TITLE
Add TaskType classification to to-do items

### DIFF
--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Create.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Create.sql
@@ -1,13 +1,14 @@
-CREATE PROCEDURE [dbo].[sp_ToDos_Create] @Id UNIQUEIDENTIFIER,
-                                         @NumberedId INT,
-                                         @Title NVARCHAR(100),
+CREATE PROCEDURE [dbo].[sp_ToDos_Create] @Id          UNIQUEIDENTIFIER,
+                                         @NumberedId  INT,
+                                         @Title       NVARCHAR(100),
                                          @Description NVARCHAR(MAX),
-                                         @CreatedAt DATETIME,
-                                         @DueDate DATETIME,
-                                         @Status INT,
-                                         @AssignedTo UNIQUEIDENTIFIER,
-                                         @TeamId UNIQUEIDENTIFIER,
-                                         @ProjectId UNIQUEIDENTIFIER
+                                         @CreatedAt   DATETIME,
+                                         @DueDate     DATETIME,
+                                         @Status      INT,
+                                         @AssignedTo  UNIQUEIDENTIFIER,
+                                         @TeamId      UNIQUEIDENTIFIER,
+                                         @ProjectId   UNIQUEIDENTIFIER,
+                                         @Type        INT
 AS
 INSERT INTO [dbo].[ToDos] (Id,
                            Title,
@@ -18,7 +19,8 @@ INSERT INTO [dbo].[ToDos] (Id,
                            AssignedTo,
                            NumberedId,
                            TeamId,
-                           ProjectId)
+                           ProjectId,
+                           Type)
 VALUES (@Id,
         @Title,
         @Description,
@@ -28,4 +30,5 @@ VALUES (@Id,
         @AssignedTo,
         (SELECT ISNULL(MAX(NumberedId), 0) + 1 FROM [dbo].[ToDos]),
         @TeamId,
-        @ProjectId)
+        @ProjectId,
+        @Type)

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetAll.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetAll.sql
@@ -9,5 +9,6 @@ SELECT Id,
        AssignedTo,
        NumberedId,
        TeamId,
-       ProjectId
+       ProjectId,
+       Type
 FROM [dbo].[ToDos]

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByAssignedTo.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByAssignedTo.sql
@@ -9,6 +9,7 @@ SELECT Id,
        AssignedTo,
        NumberedId,
        TeamId,
-       ProjectId
+       ProjectId,
+       Type
 FROM [dbo].[ToDos]
 WHERE AssignedTo = @AssignedTo

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetById.sql
@@ -9,6 +9,7 @@ SELECT Id,
        AssignedTo,
        NumberedId,
        TeamId,
-       ProjectId
+       ProjectId,
+       Type
 FROM [dbo].[ToDos]
 WHERE Id = @Id

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByNearestDueDateByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByNearestDueDateByUserId.sql
@@ -12,7 +12,8 @@ BEGIN
            AssignedTo,
            NumberedId,
            TeamId,
-           ProjectId
+           ProjectId,
+           Type
     FROM [dbo].[ToDos]
     WHERE AssignedTo = @UserId
       AND DueDate IS NOT NULL

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByProjectId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByProjectId.sql
@@ -13,7 +13,8 @@ BEGIN
         AssignedTo,
         NumberedId,
         TeamId,
-        ProjectId
+        ProjectId,
+        Type
     FROM [dbo].[ToDos]
     WHERE ProjectId = @ProjectId;
 END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByTeamId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetByTeamId.sql
@@ -11,7 +11,8 @@ BEGIN
            AssignedTo,
            NumberedId,
            TeamId,
-           ProjectId
+           ProjectId,
+           Type
     FROM [dbo].[ToDos]
     WHERE TeamId = @TeamId;
 END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetCountByUserIdAndStatus.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_GetCountByUserIdAndStatus.sql
@@ -1,10 +1,20 @@
-﻿CREATE PROCEDURE [dbo].[sp_ToDos_GetCountByUserIdAndStatus] @UserId UNIQUEIDENTIFIER,
+CREATE PROCEDURE [dbo].[sp_ToDos_GetCountByUserIdAndStatus] @UserId     UNIQUEIDENTIFIER,
                                                             @ToDoStatus INT
 AS
 BEGIN
     SET NOCOUNT ON;
-    SELECT *
-    FROM ToDos
+    SELECT Id,
+           Title,
+           Description,
+           CreatedAt,
+           DueDate,
+           Status,
+           AssignedTo,
+           NumberedId,
+           TeamId,
+           ProjectId,
+           Type
+    FROM [dbo].[ToDos]
     WHERE [AssignedTo] = @UserId
-      AND [Status] = @ToDoStatus;
+      AND [Status]     = @ToDoStatus;
 END

--- a/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Update.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/ToDos/sp_ToDos_Update.sql
@@ -1,13 +1,14 @@
-CREATE PROCEDURE [dbo].[sp_ToDos_Update] @Id UNIQUEIDENTIFIER,
-                                         @Title NVARCHAR(100),
+CREATE PROCEDURE [dbo].[sp_ToDos_Update] @Id          UNIQUEIDENTIFIER,
+                                         @Title       NVARCHAR(100),
                                          @Description NVARCHAR(MAX),
-                                         @CreatedAt DATETIME,
-                                         @DueDate DATETIME,
-                                         @Status INT,
-                                         @AssignedTo UNIQUEIDENTIFIER,
-                                         @NumberedId INT,
-                                         @TeamId UNIQUEIDENTIFIER,
-                                         @ProjectId UNIQUEIDENTIFIER
+                                         @CreatedAt   DATETIME,
+                                         @DueDate     DATETIME,
+                                         @Status      INT,
+                                         @AssignedTo  UNIQUEIDENTIFIER,
+                                         @NumberedId  INT,
+                                         @TeamId      UNIQUEIDENTIFIER,
+                                         @ProjectId   UNIQUEIDENTIFIER,
+                                         @Type        INT
 AS
 UPDATE [dbo].[ToDos]
 SET Title       = @Title,
@@ -17,5 +18,6 @@ SET Title       = @Title,
     Status      = @Status,
     AssignedTo  = @AssignedTo,
     TeamId      = @TeamId,
-    ProjectId   = @ProjectId
+    ProjectId   = @ProjectId,
+    Type        = @Type
 WHERE Id = @Id

--- a/ToDoTimeManager.DataBase/Tables/ToDos.sql
+++ b/ToDoTimeManager.DataBase/Tables/ToDos.sql
@@ -10,6 +10,7 @@
     AssignedTo  UNIQUEIDENTIFIER NULL,
     TeamId      UNIQUEIDENTIFIER NULL,
     ProjectId   UNIQUEIDENTIFIER NULL,
+    Type        INT              NULL,
     CONSTRAINT [FK_ToDos_Users] FOREIGN KEY ([AssignedTo]) REFERENCES [Users] ([Id]),
     CONSTRAINT [FK_ToDos_Teams] FOREIGN KEY ([TeamId]) REFERENCES [Teams] ([Id]),
     CONSTRAINT [FK_ToDos_Projects] FOREIGN KEY ([ProjectId]) REFERENCES [Projects] ([Id])

--- a/ToDoTimeManager.Shared/DTOs/ToDoUpsertRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/ToDoUpsertRequestDto.cs
@@ -24,6 +24,9 @@ public sealed class ToDoUpsertRequestDto
 
     [Required] public ToDoStatus? Status { get; set; }
 
+    /// <summary>The work classification. Optional; null means unclassified.</summary>
+    public TaskType? Type { get; set; }
+
     public Guid? AssignedTo { get; set; }
 
     public Guid? TeamId { get; set; }

--- a/ToDoTimeManager.Shared/Enums/TaskType.cs
+++ b/ToDoTimeManager.Shared/Enums/TaskType.cs
@@ -1,0 +1,15 @@
+namespace ToDoTimeManager.Shared.Enums;
+
+/// <summary>
+/// Classifies a to-do item by work type.
+/// Stored as INT in the database; the column is nullable for backwards compatibility.
+/// </summary>
+public enum TaskType
+{
+    UserStory = 0,
+    Feature   = 1,
+    Bug       = 2,
+    Incident  = 3,
+    Support   = 4,
+    Meet      = 5
+}

--- a/ToDoTimeManager.Shared/Models/ToDo.cs
+++ b/ToDoTimeManager.Shared/Models/ToDo.cs
@@ -17,6 +17,10 @@ public class ToDo
         : "-";
 
     public ToDoStatus Status { get; set; } = ToDoStatus.New;
+
+    /// <summary>Gets or sets the work classification of this to-do item.</summary>
+    public TaskType? Type { get; set; }
+
     public Guid? AssignedTo { get; set; }
     public Guid? TeamId { get; set; }
     public Guid? ProjectId { get; set; }

--- a/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
+++ b/ToDoTimeManager.WebApi/Controllers/ToDosController.cs
@@ -89,6 +89,7 @@ public class ToDosController : BaseController
             CreatedAt = request.CreatedAt!.Value,
             DueDate = request.DueDate,
             Status = request.Status!.Value,
+            Type = request.Type,
             AssignedTo = request.AssignedTo,
             TeamId = request.TeamId,
             ProjectId = request.ProjectId
@@ -121,6 +122,7 @@ public class ToDosController : BaseController
             CreatedAt = request.CreatedAt!.Value,
             DueDate = request.DueDate,
             Status = request.Status!.Value,
+            Type = request.Type,
             AssignedTo = request.AssignedTo,
             TeamId = request.TeamId,
             ProjectId = request.ProjectId

--- a/ToDoTimeManager.WebApi/Entities/ToDoEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/ToDoEntity.cs
@@ -17,6 +17,7 @@ public class ToDoEntity
         CreatedAt = toDo.CreatedAt;
         DueDate = toDo.DueDate;
         Status = toDo.Status;
+        Type = toDo.Type;
         AssignedTo = toDo.AssignedTo;
         NumberedId = toDo.NumberedId;
         TeamId = toDo.TeamId;
@@ -31,6 +32,7 @@ public class ToDoEntity
     public DateTime CreatedAt { get; set; }
     public DateTime? DueDate { get; set; }
     public ToDoStatus Status { get; set; }
+    public TaskType? Type { get; set; }
     public Guid? AssignedTo { get; set; }
     public Guid? TeamId { get; set; }
     public Guid? ProjectId { get; set; }
@@ -45,6 +47,7 @@ public class ToDoEntity
             CreatedAt = CreatedAt,
             DueDate = DueDate,
             Status = Status,
+            Type = Type,
             AssignedTo = AssignedTo,
             NumberedId = NumberedId,
             TeamId = TeamId,


### PR DESCRIPTION
## Summary
This PR introduces a new `TaskType` enum to classify to-do items by work type (UserStory, Feature, Bug, Incident, Support, Meet). The `Type` field is added throughout the data model, database schema, stored procedures, and API layer.

## Key Changes
- **New Enum**: Created `TaskType.cs` in `ToDoTimeManager.Shared.Enums` with six classification values
- **Database Schema**: Added nullable `Type INT` column to the `ToDos` table for backwards compatibility
- **Stored Procedures**: Updated all 10 stored procedures to include the `Type` parameter and column:
  - Create and Update procedures now accept `@Type` parameter
  - All SELECT procedures explicitly list `Type` column (replacing `SELECT *`)
  - Improved parameter alignment formatting for consistency
- **Data Models**: 
  - Added `TaskType? Type` property to `ToDo` model
  - Added `TaskType? Type` property to `ToDoEntity` with mapping logic
  - Added `TaskType? Type` property to `ToDoUpsertRequestDto`
- **API Controller**: Updated `CreateToDo` and `UpdateToDo` endpoints to map `Type` from request to domain model

## Implementation Details
- The `Type` field is nullable to maintain backwards compatibility with existing to-do items
- All SELECT statements in stored procedures now use explicit column lists instead of `SELECT *` for better maintainability
- Parameter formatting in stored procedures was standardized with aligned spacing for readability

https://claude.ai/code/session_01BhMex7dVo8DqbUtPAWrSxB