### PR TITLE
Add ProjectType enum and thread it through the full stack

### DIFF
--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_Create.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_Create.sql
@@ -3,10 +3,11 @@ CREATE PROCEDURE [dbo].[sp_Projects_Create]
     @Name        NVARCHAR(100),
     @Description NVARCHAR(500),
     @CreatedAt   DATETIME,
-    @CreatedBy   UNIQUEIDENTIFIER
+    @CreatedBy   UNIQUEIDENTIFIER,
+    @Type        INT = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
-    INSERT INTO [dbo].[Projects] (Id, Name, Description, CreatedAt, CreatedBy)
-    VALUES (@Id, @Name, @Description, @CreatedAt, @CreatedBy);
+    INSERT INTO [dbo].[Projects] (Id, Name, Description, CreatedAt, CreatedBy, Type)
+    VALUES (@Id, @Name, @Description, @CreatedAt, @CreatedBy, @Type);
 END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetAll.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetAll.sql
@@ -8,9 +8,10 @@ BEGIN
         p.Description,
         p.CreatedAt,
         p.CreatedBy,
+        p.Type,
         COUNT(pt.Id) AS TeamCount
     FROM [dbo].[Projects] p
     LEFT JOIN [dbo].[ProjectTeams] pt ON pt.ProjectId = p.Id
-    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy
+    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy, p.Type
     ORDER BY p.Name ASC;
 END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetById.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetById.sql
@@ -9,9 +9,10 @@ BEGIN
         p.Description,
         p.CreatedAt,
         p.CreatedBy,
+        p.Type,
         COUNT(pt.Id) AS TeamCount
     FROM [dbo].[Projects] p
     LEFT JOIN [dbo].[ProjectTeams] pt ON pt.ProjectId = p.Id
     WHERE p.Id = @Id
-    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy;
+    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy, p.Type;
 END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetByUserId.sql
@@ -9,11 +9,12 @@ BEGIN
         p.Description,
         p.CreatedAt,
         p.CreatedBy,
+        p.Type,
         COUNT(pt2.Id) AS TeamCount
     FROM [dbo].[Projects] p
     INNER JOIN [dbo].[ProjectTeams] pt  ON pt.ProjectId  = p.Id
     INNER JOIN [dbo].[TeamMembers]  tm  ON tm.TeamId     = pt.TeamId AND tm.UserId = @UserId
     LEFT  JOIN [dbo].[ProjectTeams] pt2 ON pt2.ProjectId = p.Id
-    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy
+    GROUP BY p.Id, p.Name, p.Description, p.CreatedAt, p.CreatedBy, p.Type
     ORDER BY p.Name ASC;
 END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_Update.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_Update.sql
@@ -1,12 +1,14 @@
 CREATE PROCEDURE [dbo].[sp_Projects_Update]
     @Id          UNIQUEIDENTIFIER,
     @Name        NVARCHAR(100),
-    @Description NVARCHAR(500)
+    @Description NVARCHAR(500),
+    @Type        INT = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
     UPDATE [dbo].[Projects]
     SET Name        = @Name,
-        Description = @Description
+        Description = @Description,
+        Type        = @Type
     WHERE Id = @Id;
 END

--- a/ToDoTimeManager.DataBase/Tables/Projects.sql
+++ b/ToDoTimeManager.DataBase/Tables/Projects.sql
@@ -5,5 +5,9 @@ CREATE TABLE [dbo].[Projects]
     Description NVARCHAR(500)    NULL,
     CreatedAt   DATETIME         NOT NULL,
     CreatedBy   UNIQUEIDENTIFIER NOT NULL,
+    Type        INT              NULL,
     CONSTRAINT [FK_Projects_Users_CreatedBy] FOREIGN KEY ([CreatedBy]) REFERENCES [Users]([Id])
 )
+
+-- Migration: run once on existing databases
+-- ALTER TABLE [dbo].[Projects] ADD Type INT NULL;

--- a/ToDoTimeManager.Shared/DTOs/CreateProjectRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/CreateProjectRequestDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Utils;
 
 namespace ToDoTimeManager.Shared.DTOs;
@@ -13,4 +14,6 @@ public sealed class CreateProjectRequestDto
     public string Name { get; set; } = string.Empty;
 
     [MaxLength(500)] public string? Description { get; set; }
+
+    public ProjectType? Type { get; set; }
 }

--- a/ToDoTimeManager.Shared/DTOs/ProjectResponseDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/ProjectResponseDto.cs
@@ -1,3 +1,4 @@
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.Shared.DTOs;
@@ -10,5 +11,6 @@ public sealed class ProjectResponseDto
     public DateTime CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
     public int TeamCount { get; set; }
+    public ProjectType? Type { get; set; }
     public List<ProjectTeam>? Teams { get; set; }
 }

--- a/ToDoTimeManager.Shared/DTOs/UpdateProjectRequestDto.cs
+++ b/ToDoTimeManager.Shared/DTOs/UpdateProjectRequestDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Utils;
 
 namespace ToDoTimeManager.Shared.DTOs;
@@ -13,4 +14,6 @@ public sealed class UpdateProjectRequestDto
     public string Name { get; set; } = string.Empty;
 
     [MaxLength(500)] public string? Description { get; set; }
+
+    public ProjectType? Type { get; set; }
 }

--- a/ToDoTimeManager.Shared/Enums/ProjectType.cs
+++ b/ToDoTimeManager.Shared/Enums/ProjectType.cs
@@ -1,0 +1,18 @@
+namespace ToDoTimeManager.Shared.Enums;
+
+/// <summary>
+/// Classifies a project by its primary domain.
+/// Stored as INT in the database; the column is nullable for backwards compatibility.
+/// </summary>
+public enum ProjectType
+{
+    Backend     = 0,
+    Frontend    = 1,
+    DataBase    = 2,
+    FullStack   = 3,
+    Mobile      = 4,
+    DevOps      = 5,
+    DataScience = 6,
+    Security    = 7,
+    Other       = 8
+}

--- a/ToDoTimeManager.Shared/Extensions/MappingExtensions.cs
+++ b/ToDoTimeManager.Shared/Extensions/MappingExtensions.cs
@@ -35,6 +35,7 @@ public static class MappingExtensions
             CreatedAt = project.CreatedAt,
             CreatedBy = project.CreatedBy,
             TeamCount = project.TeamCount,
+            Type = project.Type,
             Teams = teams
         };
 }

--- a/ToDoTimeManager.Shared/Models/Project.cs
+++ b/ToDoTimeManager.Shared/Models/Project.cs
@@ -1,3 +1,5 @@
+using ToDoTimeManager.Shared.Enums;
+
 namespace ToDoTimeManager.Shared.Models;
 
 public class Project
@@ -8,4 +10,5 @@ public class Project
     public DateTime CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
     public int TeamCount { get; set; }
+    public ProjectType? Type { get; set; }
 }

--- a/ToDoTimeManager.WebApi/Entities/ProjectEntity.cs
+++ b/ToDoTimeManager.WebApi/Entities/ProjectEntity.cs
@@ -1,3 +1,4 @@
+using ToDoTimeManager.Shared.Enums;
 using ToDoTimeManager.Shared.Models;
 
 namespace ToDoTimeManager.WebApi.Entities;
@@ -15,6 +16,7 @@ public class ProjectEntity
         Description = project.Description;
         CreatedAt = project.CreatedAt;
         CreatedBy = project.CreatedBy;
+        Type = project.Type;
     }
 
     public Guid Id { get; set; }
@@ -23,6 +25,7 @@ public class ProjectEntity
     public DateTime CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
     public int TeamCount { get; set; }
+    public ProjectType? Type { get; set; }
 
     public Project ToProject()
     {
@@ -33,7 +36,8 @@ public class ProjectEntity
             Description = Description,
             CreatedAt = CreatedAt,
             CreatedBy = CreatedBy,
-            TeamCount = TeamCount
+            TeamCount = TeamCount,
+            Type = Type
         };
     }
 }

--- a/ToDoTimeManager.WebApi/Services/Implementations/ProjectsService.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/ProjectsService.cs
@@ -92,7 +92,8 @@ public class ProjectsService : IProjectsService
                 Name = request.Name,
                 Description = request.Description,
                 CreatedAt = DateTime.UtcNow,
-                CreatedBy = createdByUserId
+                CreatedBy = createdByUserId,
+                Type = request.Type
             };
             return await _projectsDataController.CreateProject(entity);
         }
@@ -121,7 +122,8 @@ public class ProjectsService : IProjectsService
             {
                 Id = request.Id,
                 Name = request.Name,
-                Description = request.Description
+                Description = request.Description,
+                Type = request.Type
             };
             return await _projectsDataController.UpdateProject(entity);
         }

--- a/ToDoTimeManager.WebUI/Resources/Resource.en-US.resx
+++ b/ToDoTimeManager.WebUI/Resources/Resource.en-US.resx
@@ -204,4 +204,31 @@
   <data name="two-fa_step-label" xml:space="preserve">
     <value>Two-factor auth</value>
   </data>
+  <data name="ProjectType_Backend" xml:space="preserve">
+    <value>Backend</value>
+  </data>
+  <data name="ProjectType_Frontend" xml:space="preserve">
+    <value>Frontend</value>
+  </data>
+  <data name="ProjectType_DataBase" xml:space="preserve">
+    <value>Database</value>
+  </data>
+  <data name="ProjectType_FullStack" xml:space="preserve">
+    <value>Full Stack</value>
+  </data>
+  <data name="ProjectType_Mobile" xml:space="preserve">
+    <value>Mobile</value>
+  </data>
+  <data name="ProjectType_DevOps" xml:space="preserve">
+    <value>DevOps</value>
+  </data>
+  <data name="ProjectType_DataScience" xml:space="preserve">
+    <value>Data Science</value>
+  </data>
+  <data name="ProjectType_Security" xml:space="preserve">
+    <value>Security</value>
+  </data>
+  <data name="ProjectType_Other" xml:space="preserve">
+    <value>Other</value>
+  </data>
 </root>

--- a/ToDoTimeManager.WebUI/Resources/Resource.resx
+++ b/ToDoTimeManager.WebUI/Resources/Resource.resx
@@ -204,4 +204,31 @@
   <data name="two-fa_step-label" xml:space="preserve">
     <value>Two-factor auth</value>
   </data>
+  <data name="ProjectType_Backend" xml:space="preserve">
+    <value>Бекенд</value>
+  </data>
+  <data name="ProjectType_Frontend" xml:space="preserve">
+    <value>Фронтенд</value>
+  </data>
+  <data name="ProjectType_DataBase" xml:space="preserve">
+    <value>База даних</value>
+  </data>
+  <data name="ProjectType_FullStack" xml:space="preserve">
+    <value>Повний стек</value>
+  </data>
+  <data name="ProjectType_Mobile" xml:space="preserve">
+    <value>Мобільна розробка</value>
+  </data>
+  <data name="ProjectType_DevOps" xml:space="preserve">
+    <value>DevOps</value>
+  </data>
+  <data name="ProjectType_DataScience" xml:space="preserve">
+    <value>Наука про дані</value>
+  </data>
+  <data name="ProjectType_Security" xml:space="preserve">
+    <value>Безпека</value>
+  </data>
+  <data name="ProjectType_Other" xml:space="preserve">
+    <value>Інше</value>
+  </data>
 </root>

--- a/ToDoTimeManager.WebUI/Resources/Resource.uk-UA.resx
+++ b/ToDoTimeManager.WebUI/Resources/Resource.uk-UA.resx
@@ -204,4 +204,31 @@
   <data name="two-fa_step-label" xml:space="preserve">
     <value>Двоетапна перевірка</value>
   </data>
+  <data name="ProjectType_Backend" xml:space="preserve">
+    <value>Бекенд</value>
+  </data>
+  <data name="ProjectType_Frontend" xml:space="preserve">
+    <value>Фронтенд</value>
+  </data>
+  <data name="ProjectType_DataBase" xml:space="preserve">
+    <value>База даних</value>
+  </data>
+  <data name="ProjectType_FullStack" xml:space="preserve">
+    <value>Повний стек</value>
+  </data>
+  <data name="ProjectType_Mobile" xml:space="preserve">
+    <value>Мобільна розробка</value>
+  </data>
+  <data name="ProjectType_DevOps" xml:space="preserve">
+    <value>DevOps</value>
+  </data>
+  <data name="ProjectType_DataScience" xml:space="preserve">
+    <value>Наука про дані</value>
+  </data>
+  <data name="ProjectType_Security" xml:space="preserve">
+    <value>Безпека</value>
+  </data>
+  <data name="ProjectType_Other" xml:space="preserve">
+    <value>Інше</value>
+  </data>
 </root>


### PR DESCRIPTION
Introduces a nullable ProjectType (Backend, Frontend, DataBase, FullStack,
Mobile, DevOps, DataScience, Security, Other) that classifies each project.
Changes span: new Shared enum, Project model, request/response DTOs,
MappingExtensions, ProjectEntity, ProjectsService, all five Projects stored
procedures, the Projects table definition, and localization strings (en-US /
uk-UA).

https://claude.ai/code/session_01WhgvBfPJfHJYDyXEaLwd2g