### PR TITLE
Add mailto link for admin contact on auth page

### DIFF
--- a/ToDoTimeManager.WebUI/Components/Pages/AuthPage/LoginForm.razor
+++ b/ToDoTimeManager.WebUI/Components/Pages/AuthPage/LoginForm.razor
@@ -69,5 +69,5 @@
 </Button>
 
 <div class="footer-line">
-    @Localizer["Trouble signing in?"] <a href="#">@Localizer["Contact your forge admin"]</a>
+    @Localizer["Trouble signing in?"] <a href="mailto:dmitro.danko@gmail.com?subject=Звернення до адміна">@Localizer["Contact your forge admin"]</a>
 </div>

--- a/ToDoTimeManager.WebUI/Components/Pages/AuthPage/TwoFAForm.razor
+++ b/ToDoTimeManager.WebUI/Components/Pages/AuthPage/TwoFAForm.razor
@@ -65,7 +65,7 @@
     <a @onclick="OnUseDifferentEmailClicked" @onclick:preventDefault href="#">
         <span>@Localizer["Use a different email"]</span>
     </a>
-    <a href="#">
+    <a href="mailto:dmitro.danko@gmail.com?subject=Звернення до адміна">
         <span>@Localizer["Lost access? Contact admin"]</span>
     </a>
 </div>


### PR DESCRIPTION
## Summary
- Замінено `href="#"` на `mailto:dmitro.danko@gmail.com?subject=Звернення до адміна` у посиланні "Contact your forge admin" в `LoginForm.razor`
- Замінено `href="#"` на `mailto:dmitro.danko@gmail.com?subject=Звернення до адміна` у посиланні "Lost access? Contact admin" в `TwoFAForm.razor`

## Test plan
- [ ] Відкрити `/auth` → клікнути "Contact your forge admin" → відкривається поштовий клієнт з адресою `dmitro.danko@gmail.com` і темою `Звернення до адміна`
- [ ] Перейти до форми 2FA → клікнути "Lost access? Contact admin" → те саме

https://claude.ai/code/session_01X9eucvb16LkDfu88UgAcTp

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9eucvb16LkDfu88UgAcTp)_