### PR TITLE
Add schema change detection to DbPublisher

### DIFF
--- a/ToDoTimeManager.DbPublisher/Program.cs
+++ b/ToDoTimeManager.DbPublisher/Program.cs
@@ -66,16 +66,44 @@ if (!File.Exists(dacpacPath))
 Console.WriteLine($"Loading publish profile: {publishXmlPath}");
 var profile = DacProfile.Load(publishXmlPath);
 
-Console.WriteLine($"Publishing '{profile.TargetDatabaseName}'...");
 var dacServices = new DacServices(profile.TargetConnectionString);
 dacServices.Message += (_, e) => Console.WriteLine(e.Message);
 dacServices.ProgressChanged += (_, e) => Console.WriteLine($"[{e.Status}] {e.Message}");
 
 using var dacPackage = DacPackage.Load(dacpacPath);
+
+// --- Check for schema differences before publishing ---
+Console.WriteLine($"Checking '{profile.TargetDatabaseName}' for schema differences...");
+
+try
+{
+    var deployReport = dacServices.GenerateDeployReport(
+        dacPackage,
+        targetDatabaseName: profile.TargetDatabaseName,
+        options: profile.DeployOptions);
+
+    var doc = System.Xml.Linq.XDocument.Parse(deployReport);
+    var ns = doc.Root?.Name.Namespace ?? System.Xml.Linq.XNamespace.None;
+    var operationCount = doc.Descendants(ns + "Operation").Count();
+
+    if (operationCount == 0)
+    {
+        Console.WriteLine("Database is already up to date. Skipping publish.");
+        return 0;
+    }
+
+    Console.WriteLine($"Detected {operationCount} pending schema operation(s). Publishing...");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Schema comparison failed ({ex.Message}). Proceeding with publish to be safe.");
+}
+
 dacServices.Deploy(dacPackage, targetDatabaseName: profile.TargetDatabaseName,
     upgradeExisting: true, options: profile.DeployOptions);
 
 Console.WriteLine("Database published successfully.");
+
 return 0;
 
 static (int ExitCode, string StdOut, string StdErr) Run(string fileName, string arguments)


### PR DESCRIPTION
## Summary

- Added `DacServices.GenerateDeployReport()` call before every deploy to compare the built DACPAC against the current database schema
- If no schema operations are detected, the publish is skipped with a "Database is already up to date" message
- If the comparison fails (e.g. database does not exist yet or connection error), falls back to a full publish to stay safe

## Test plan

- [ ] First run with a fresh database — should publish all objects normally
- [ ] Second run with no schema changes — should print "Database is already up to date. Skipping publish." and exit 0 without deploying
- [ ] Run after adding a new table/stored procedure to the `.sqlproj` — should detect the change and publish

https://claude.ai/code/session_01Jujk76SZc9xB6vY88isK1j

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jujk76SZc9xB6vY88isK1j)_