### PR TITLE
Add missing translation keys (Log In, Register, Settings, Logout, etc.)

### DIFF
--- a/ToDoTimeManager.WebUI.Components/Resources/Resource.en-US.resx
+++ b/ToDoTimeManager.WebUI.Components/Resources/Resource.en-US.resx
@@ -387,4 +387,25 @@
   <data name="TOTP QR code" xml:space="preserve">
     <value>TOTP QR code</value>
   </data>
+  <data name="Log In" xml:space="preserve">
+    <value>Log In</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Register</value>
+  </data>
+  <data name="Already have an account?" xml:space="preserve">
+    <value>Already have an account?</value>
+  </data>
+  <data name="Two Factor Authentication" xml:space="preserve">
+    <value>Two Factor Authentication</value>
+  </data>
+  <data name="Search for tasks, time logs, projects..." xml:space="preserve">
+    <value>Search for tasks, time logs, projects...</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Log out</value>
+  </data>
 </root>

--- a/ToDoTimeManager.WebUI.Components/Resources/Resource.resx
+++ b/ToDoTimeManager.WebUI.Components/Resources/Resource.resx
@@ -172,7 +172,7 @@
     <value>Contact your forge admin</value>
   </data>
   <data name="Terms of Service" xml:space="preserve">
-    <value>Умови використання</value>
+    <value>Terms of Service</value>
   </data>
   <data name="Forge clarity" xml:space="preserve">
     <value>Forge clarity</value>
@@ -386,5 +386,26 @@
   </data>
   <data name="TOTP QR code" xml:space="preserve">
     <value>QR-код TOTP</value>
+  </data>
+  <data name="Log In" xml:space="preserve">
+    <value>Увійти</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Реєстрація</value>
+  </data>
+  <data name="Already have an account?" xml:space="preserve">
+    <value>Вже є акаунт?</value>
+  </data>
+  <data name="Two Factor Authentication" xml:space="preserve">
+    <value>Двофакторна автентифікація</value>
+  </data>
+  <data name="Search for tasks, time logs, projects..." xml:space="preserve">
+    <value>Пошук задач, записів часу, проектів...</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Налаштування</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Вийти</value>
   </data>
 </root>

--- a/ToDoTimeManager.WebUI.Components/Resources/Resource.uk-UA.resx
+++ b/ToDoTimeManager.WebUI.Components/Resources/Resource.uk-UA.resx
@@ -387,4 +387,25 @@
   <data name="TOTP QR code" xml:space="preserve">
     <value>QR-код TOTP</value>
   </data>
+  <data name="Log In" xml:space="preserve">
+    <value>Увійти</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Реєстрація</value>
+  </data>
+  <data name="Already have an account?" xml:space="preserve">
+    <value>Вже є акаунт?</value>
+  </data>
+  <data name="Two Factor Authentication" xml:space="preserve">
+    <value>Двофакторна автентифікація</value>
+  </data>
+  <data name="Search for tasks, time logs, projects..." xml:space="preserve">
+    <value>Пошук задач, записів часу, проектів...</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Налаштування</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Вийти</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

- Added 7 missing localization keys to all three `.resx` files (`Resource.resx`, `Resource.uk-UA.resx`, `Resource.en-US.resx`) that were referenced in components but had no resource entries
- Fixed a bug in `Resource.resx` where `"Terms of Service"` had an incorrect Ukrainian value (`"Умови використання"`) instead of the English fallback

## Missing keys added

| Key | Component | uk-UA value | en-US value |
|-----|-----------|-------------|-------------|
| `Log In` | `LoginForm.razor:7` | Увійти | Log In |
| `Register` | `RegisterForm.razor:7` | Реєстрація | Register |
| `Already have an account?` | `RegisterForm.razor:8` | Вже є акаунт? | Already have an account? |
| `Two Factor Authentication` | `TwoFAForm.razor:6` | Двофакторна автентифікація | Two Factor Authentication |
| `Search for tasks, time logs, projects...` | `NavMenu.razor:9` | Пошук задач, записів часу, проектів... | Search for tasks, time logs, projects... |
| `Settings` | `NavMenu.razor:46` | Налаштування | Settings |
| `Logout` | `NavMenu.razor:53` | Вийти | Log out |

## Test plan

- [ ] Switch culture to `uk-UA` and verify Login page title shows "Увійти", Register page shows "Реєстрація", NavMenu shows "Налаштування" / "Вийти"
- [ ] Switch culture to `en-US` and verify Login page title shows "Log In", Register page shows "Register", NavMenu shows "Settings" / "Log out"
- [ ] Verify `Terms of Service` link text on register form shows correct English text under `en-US`

https://claude.ai/code/session_01Txs8E76Era1iPy78TAWxpn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txs8E76Era1iPy78TAWxpn)_