### PR TITLE
Add SignalR infrastructure: hub, notifier, and client service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -625,3 +625,7 @@ All SVG icon components as individual `.razor` files (Bootstrap Icons). Country 
 11. **New utility service** — add the interface to `Business.Utils/Interfaces/` and the implementation to `Business.Utils/Implementations/`; register in `WebApi/Program.cs`.
 
 12. **New SQL file** — every new `.sql` file (stored procedure, table, or migration) must be registered in `ToDoTimeManager.DataBase.sqlproj`.
+
+13. **ID-only queries** — when a service or hub needs only entity identifiers (not full entity data), add a dedicated `GetXxxIdsByYyy(Guid id)` method returning `List<Guid>`. Follow the full stack: new stored procedure (`SELECT Id FROM ... WHERE ...`) → data controller interface + implementation → business service interface + implementation. Never fetch a full entity just to extract its `Id`.
+
+14. **Razor component code placement** — always use a code-behind file (`ComponentName.razor.cs`, `partial class`) for any component that contains methods or lifecycle overrides. Use `[Inject]` in the code-behind for DI — do not add `@inject` in the `.razor` file. Inline `@code {}` is allowed only when the component declares parameters and nothing else (no methods, no lifecycle overrides, no fields beyond parameters).

--- a/ToDoTimeManager.Business/Services/Implementations/ProjectsService.cs
+++ b/ToDoTimeManager.Business/Services/Implementations/ProjectsService.cs
@@ -75,6 +75,9 @@ public class ProjectsService : IProjectsService
         return entities.Select(e => e.ToProject().ToResponseDto(null)).ToList();
     }
 
+    public Task<List<Guid>> GetProjectIdsByUserId(Guid userId)
+        => _projectsDataController.GetProjectIdsByUserId(userId);
+
     public async Task<bool> CreateProject(CreateProjectRequestDto request, Guid createdByUserId)
     {
         if (string.IsNullOrWhiteSpace(request.Name))

--- a/ToDoTimeManager.Business/Services/Implementations/TeamsService.cs
+++ b/ToDoTimeManager.Business/Services/Implementations/TeamsService.cs
@@ -68,6 +68,9 @@ public class TeamsService : ITeamsService
         return entities.Select(e => e.ToTeam().ToResponseDto(null)).ToList();
     }
 
+    public Task<List<Guid>> GetTeamIdsByUserId(Guid userId)
+        => _teamsDataController.GetTeamIdsByUserId(userId);
+
     public async Task<bool> CreateTeam(CreateTeamRequestDto request, Guid createdByUserId)
     {
         if (string.IsNullOrWhiteSpace(request.Name))

--- a/ToDoTimeManager.Business/Services/Interfaces/IProjectsService.cs
+++ b/ToDoTimeManager.Business/Services/Interfaces/IProjectsService.cs
@@ -9,6 +9,7 @@ public interface IProjectsService
     Task<List<ProjectResponseDto>> GetAllProjects(Guid currentUserId, UserRole currentUserRole);
     Task<ProjectResponseDto?> GetProjectById(Guid projectId, Guid currentUserId, UserRole currentUserRole);
     Task<List<ProjectResponseDto>> GetProjectsByUserId(Guid userId);
+    Task<List<Guid>> GetProjectIdsByUserId(Guid userId);
     Task<bool> CreateProject(CreateProjectRequestDto request, Guid createdByUserId);
     Task<bool> UpdateProject(UpdateProjectRequestDto request, Guid currentUserId, UserRole currentUserRole);
     Task<bool> DeleteProject(Guid projectId);

--- a/ToDoTimeManager.Business/Services/Interfaces/ITeamsService.cs
+++ b/ToDoTimeManager.Business/Services/Interfaces/ITeamsService.cs
@@ -9,6 +9,7 @@ public interface ITeamsService
     Task<List<TeamResponseDto>> GetAllTeams();
     Task<TeamResponseDto?> GetTeamById(Guid teamId, Guid currentUserId, UserRole currentUserRole);
     Task<List<TeamResponseDto>> GetTeamsByUserId(Guid userId);
+    Task<List<Guid>> GetTeamIdsByUserId(Guid userId);
     Task<bool> CreateTeam(CreateTeamRequestDto request, Guid createdByUserId);
     Task<bool> UpdateTeam(UpdateTeamRequestDto request, Guid currentUserId, UserRole currentUserRole);
     Task<bool> DeleteTeam(Guid teamId);

--- a/ToDoTimeManager.DataAccess/DataControllers/Implementation/ProjectsDataController.cs
+++ b/ToDoTimeManager.DataAccess/DataControllers/Implementation/ProjectsDataController.cs
@@ -54,6 +54,19 @@ public class ProjectsDataController : IProjectsDataController
         }
     }
 
+    public async Task<List<Guid>> GetProjectIdsByUserId(Guid userId)
+    {
+        try
+        {
+            return await _dbAccessService.GetAllByParameter<Guid>("sp_Projects_GetIdsByUserId", "UserId", userId);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
+
     public async Task<bool> CreateProject(ProjectEntity newProject)
     {
         try

--- a/ToDoTimeManager.DataAccess/DataControllers/Implementation/TeamsDataController.cs
+++ b/ToDoTimeManager.DataAccess/DataControllers/Implementation/TeamsDataController.cs
@@ -54,6 +54,19 @@ public class TeamsDataController : ITeamsDataController
         }
     }
 
+    public async Task<List<Guid>> GetTeamIdsByUserId(Guid userId)
+    {
+        try
+        {
+            return await _dbAccessService.GetAllByParameter<Guid>("sp_Teams_GetIdsByUserId", "UserId", userId);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return [];
+        }
+    }
+
     public async Task<bool> CreateTeam(TeamEntity newTeam)
     {
         try

--- a/ToDoTimeManager.DataAccess/DataControllers/Interfaces/IProjectsDataController.cs
+++ b/ToDoTimeManager.DataAccess/DataControllers/Interfaces/IProjectsDataController.cs
@@ -7,6 +7,7 @@ public interface IProjectsDataController
     Task<List<ProjectEntity>> GetAllProjects();
     Task<ProjectEntity?> GetProjectById(Guid projectId);
     Task<List<ProjectEntity>> GetProjectsByUserId(Guid userId);
+    Task<List<Guid>> GetProjectIdsByUserId(Guid userId);
     Task<bool> CreateProject(ProjectEntity newProject);
     Task<bool> UpdateProject(ProjectEntity updatedProject);
     Task<bool> DeleteProject(Guid projectId);

--- a/ToDoTimeManager.DataAccess/DataControllers/Interfaces/ITeamsDataController.cs
+++ b/ToDoTimeManager.DataAccess/DataControllers/Interfaces/ITeamsDataController.cs
@@ -7,6 +7,7 @@ public interface ITeamsDataController
     Task<List<TeamEntity>> GetAllTeams();
     Task<TeamEntity?> GetTeamById(Guid teamId);
     Task<List<TeamEntity>> GetTeamsByUserId(Guid userId);
+    Task<List<Guid>> GetTeamIdsByUserId(Guid userId);
     Task<bool> CreateTeam(TeamEntity newTeam);
     Task<bool> UpdateTeam(TeamEntity updatedTeam);
     Task<bool> DeleteTeam(Guid teamId);

--- a/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetIdsByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Projects/sp_Projects_GetIdsByUserId.sql
@@ -1,0 +1,15 @@
+CREATE PROCEDURE [dbo].[sp_Projects_GetIdsByUserId]
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT DISTINCT p.Id
+    FROM [dbo].[Projects] p
+    WHERE p.CreatedBy = @UserId
+       OR EXISTS (
+           SELECT 1
+           FROM   [dbo].[ProjectTeams] pt
+           JOIN   [dbo].[TeamMembers]  tm ON tm.TeamId = pt.TeamId AND tm.UserId = @UserId
+           WHERE  pt.ProjectId = p.Id
+       );
+END

--- a/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_GetIdsByUserId.sql
+++ b/ToDoTimeManager.DataBase/StoredProcedures/Teams/sp_Teams_GetIdsByUserId.sql
@@ -1,0 +1,8 @@
+CREATE PROCEDURE [dbo].[sp_Teams_GetIdsByUserId] @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT tm.TeamId
+    FROM [dbo].[TeamMembers] tm
+    WHERE tm.UserId = @UserId;
+END

--- a/ToDoTimeManager.DataBase/ToDoTimeManager.DataBase.sqlproj
+++ b/ToDoTimeManager.DataBase/ToDoTimeManager.DataBase.sqlproj
@@ -106,6 +106,7 @@
     <Build Include="StoredProcedures\Teams\sp_Teams_Update.sql" />
     <Build Include="StoredProcedures\Teams\sp_Teams_DeleteById.sql" />
     <Build Include="StoredProcedures\Teams\sp_Teams_GetByUserId.sql" />
+    <Build Include="StoredProcedures\Teams\sp_Teams_GetIdsByUserId.sql" />
     <Build Include="StoredProcedures\TeamMembers\sp_TeamMembers_Create.sql" />
     <Build Include="StoredProcedures\TeamMembers\sp_TeamMembers_GetById.sql" />
     <Build Include="StoredProcedures\TeamMembers\sp_TeamMembers_GetByTeamId.sql" />
@@ -117,6 +118,7 @@
     <Build Include="StoredProcedures\Projects\sp_Projects_Update.sql" />
     <Build Include="StoredProcedures\Projects\sp_Projects_DeleteById.sql" />
     <Build Include="StoredProcedures\Projects\sp_Projects_GetByUserId.sql" />
+    <Build Include="StoredProcedures\Projects\sp_Projects_GetIdsByUserId.sql" />
     <Build Include="StoredProcedures\ProjectTeams\sp_ProjectTeams_Create.sql" />
     <Build Include="StoredProcedures\ProjectTeams\sp_ProjectTeams_GetByProjectId.sql" />
     <Build Include="StoredProcedures\ProjectTeams\sp_ProjectTeams_GetByProjectIdAndTeamId.sql" />

--- a/ToDoTimeManager.WebApi/Hubs/CommunicationHub.cs
+++ b/ToDoTimeManager.WebApi/Hubs/CommunicationHub.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using System.Security.Claims;
+using ToDoTimeManager.Business.Services.Interfaces;
+using ToDoTimeManager.Shared.Enums;
+
+namespace ToDoTimeManager.WebApi.Hubs;
+
+[Authorize]
+public class CommunicationHub(ITeamsService teamsService, IProjectsService projectsService) : Hub
+{
+    public const string ManagersGroup = "role-managers";
+    public static string UserGroup(Guid userId)       => $"user-{userId}";
+    public static string TeamGroup(Guid teamId)       => $"team-{teamId}";
+    public static string ProjectGroup(Guid projectId) => $"project-{projectId}";
+
+    public override async Task OnConnectedAsync()
+    {
+        var userIdClaim = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        var roleClaim   = Context.User?.FindFirstValue(ClaimTypes.Role);
+
+        if (!Guid.TryParse(userIdClaim, out var userId))
+        {
+            await base.OnConnectedAsync();
+            return;
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, UserGroup(userId));
+
+        if (Enum.TryParse<UserRole>(roleClaim, out var role) && role >= UserRole.Manager)
+            await Groups.AddToGroupAsync(Context.ConnectionId, ManagersGroup);
+
+        var teamIds = await teamsService.GetTeamIdsByUserId(userId);
+        foreach (var id in teamIds)
+            await Groups.AddToGroupAsync(Context.ConnectionId, TeamGroup(id));
+
+        var projectIds = await projectsService.GetProjectIdsByUserId(userId);
+        foreach (var id in projectIds)
+            await Groups.AddToGroupAsync(Context.ConnectionId, ProjectGroup(id));
+
+        await base.OnConnectedAsync();
+    }
+}

--- a/ToDoTimeManager.WebApi/Program.cs
+++ b/ToDoTimeManager.WebApi/Program.cs
@@ -9,8 +9,11 @@ using System.Globalization;
 using System.Text;
 using System.Threading.RateLimiting;
 using ToDoTimeManager.WebApi.AdditionalComponents;
+using ToDoTimeManager.WebApi.Hubs;
 using ToDoTimeManager.WebApi.Middleware;
 using ToDoTimeManager.WebApi.Seeders;
+using ToDoTimeManager.WebApi.Services.Implementations;
+using ToDoTimeManager.WebApi.Services.Interfaces;
 using ToDoTimeManager.DataAccess.DbAccessServices;
 using ToDoTimeManager.DataAccess.DataControllers.Implementation;
 using ToDoTimeManager.DataAccess.DataControllers.Interfaces;
@@ -52,6 +55,7 @@ public class Program
         app.UseAuthentication();
         app.UseAuthorization();
         app.MapControllers();
+        app.MapHub<CommunicationHub>("/hubs/communication").RequireAuthorization();
 
         await DataSeeder.SeedAsync(app.Services);
 
@@ -61,6 +65,8 @@ public class Program
     private static void AddServices(WebApplicationBuilder builder)
     {
         builder.Services.AddControllers();
+        builder.Services.AddSignalR();
+        builder.Services.AddScoped<IHubNotifier, HubNotifier>();
         // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         builder.Services.AddEndpointsApiExplorer();
 
@@ -134,6 +140,19 @@ builder.Services.AddScoped<IActivityLogsService, ActivityLogsService>();
                             Encoding.UTF8.GetBytes(builder.Configuration["JwtSettings:Key"] ?? string.Empty)),
                     ValidateIssuerSigningKey = true,
                     ClockSkew = TimeSpan.Zero
+                };
+                options.Events = new JwtBearerEvents
+                {
+                    OnMessageReceived = context =>
+                    {
+                        var token = context.Request.Query["access_token"];
+                        if (!string.IsNullOrEmpty(token) &&
+                            context.Request.Path.StartsWithSegments("/hubs", StringComparison.OrdinalIgnoreCase))
+                        {
+                            context.Token = token;
+                        }
+                        return Task.CompletedTask;
+                    }
                 };
             })
             .AddCookie("ExternalCookieScheme", options =>

--- a/ToDoTimeManager.WebApi/Services/Implementations/HubNotifier.cs
+++ b/ToDoTimeManager.WebApi/Services/Implementations/HubNotifier.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.SignalR;
+using ToDoTimeManager.WebApi.Hubs;
+using ToDoTimeManager.WebApi.Services.Interfaces;
+
+namespace ToDoTimeManager.WebApi.Services.Implementations;
+
+public class HubNotifier(IHubContext<CommunicationHub> hubContext) : IHubNotifier
+{
+    public Task NotifyUserAsync<T>(Guid userId, string method, T payload, CancellationToken ct = default)
+        => hubContext.Clients.Group(CommunicationHub.UserGroup(userId)).SendAsync(method, payload, cancellationToken: ct);
+
+    public Task NotifyTeamAsync<T>(Guid teamId, string method, T payload, CancellationToken ct = default)
+        => hubContext.Clients.Group(CommunicationHub.TeamGroup(teamId)).SendAsync(method, payload, cancellationToken: ct);
+
+    public Task NotifyProjectAsync<T>(Guid projectId, string method, T payload, CancellationToken ct = default)
+        => hubContext.Clients.Group(CommunicationHub.ProjectGroup(projectId)).SendAsync(method, payload, cancellationToken: ct);
+
+    public Task NotifyManagersAsync<T>(string method, T payload, CancellationToken ct = default)
+        => hubContext.Clients.Group(CommunicationHub.ManagersGroup).SendAsync(method, payload, cancellationToken: ct);
+}

--- a/ToDoTimeManager.WebApi/Services/Interfaces/IHubNotifier.cs
+++ b/ToDoTimeManager.WebApi/Services/Interfaces/IHubNotifier.cs
@@ -1,0 +1,9 @@
+namespace ToDoTimeManager.WebApi.Services.Interfaces;
+
+public interface IHubNotifier
+{
+    Task NotifyUserAsync<T>(Guid userId, string method, T payload, CancellationToken ct = default);
+    Task NotifyTeamAsync<T>(Guid teamId, string method, T payload, CancellationToken ct = default);
+    Task NotifyProjectAsync<T>(Guid projectId, string method, T payload, CancellationToken ct = default);
+    Task NotifyManagersAsync<T>(string method, T payload, CancellationToken ct = default);
+}

--- a/ToDoTimeManager.WebUI.Components/Shared/Layouts/MainLayout.razor
+++ b/ToDoTimeManager.WebUI.Components/Shared/Layouts/MainLayout.razor
@@ -4,6 +4,7 @@
 @inherits LayoutComponentBase
 <AuthorizeView>
     <Authorized>
+        <SignalRConnector/>
         <ToastBox/>
         <ModalContainer/>
         <div class="page">

--- a/ToDoTimeManager.WebUI.Components/Shared/SignalRConnector.razor
+++ b/ToDoTimeManager.WebUI.Components/Shared/SignalRConnector.razor
@@ -1,0 +1,1 @@
+@* Lifecycle component — manages SignalR connection. Logic in code-behind. *@

--- a/ToDoTimeManager.WebUI.Components/Shared/SignalRConnector.razor.cs
+++ b/ToDoTimeManager.WebUI.Components/Shared/SignalRConnector.razor.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using ToDoTimeManager.WebUI.Services.Services.Interfaces;
+
+namespace ToDoTimeManager.WebUI.Components.Shared;
+
+public partial class SignalRConnector : IAsyncDisposable
+{
+    [Inject] private ISignalRService SignalRService { get; set; } = default!;
+    [Inject] private AuthenticationStateProvider Auth { get; set; } = default!;
+
+    private bool _started;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        var state = await Auth.GetAuthenticationStateAsync();
+        if (state.User.Identity?.IsAuthenticated == true)
+            await StartAsync();
+
+        Auth.AuthenticationStateChanged += OnAuthChanged;
+    }
+
+    private async void OnAuthChanged(Task<AuthenticationState> task)
+    {
+        try
+        {
+            var state = await task;
+            if (state.User.Identity?.IsAuthenticated == true)
+            {
+                if (!_started) await StartAsync();
+            }
+            else
+            {
+                await StopAsync();
+            }
+        }
+        catch { /* не крашимо circuit */ }
+    }
+
+    private async Task StartAsync()
+    {
+        await SignalRService.StartAsync();
+        _started = true;
+    }
+
+    private async Task StopAsync()
+    {
+        await SignalRService.StopAsync();
+        _started = false;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Auth.AuthenticationStateChanged -= OnAuthChanged;
+        await SignalRService.StopAsync();
+    }
+}

--- a/ToDoTimeManager.WebUI.Components/Shared/SignalRConnector.razor.cs
+++ b/ToDoTimeManager.WebUI.Components/Shared/SignalRConnector.razor.cs
@@ -39,10 +39,19 @@ public partial class SignalRConnector : IAsyncDisposable
         catch { /* не крашимо circuit */ }
     }
 
-    private async Task StartAsync()
+    private async Task<bool> StartAsync()
     {
-        await SignalRService.StartAsync();
-        _started = true;
+        try
+        {
+            await SignalRService.StartAsync();
+            _started = true;
+            return true;
+        }
+        catch
+        {
+            _started = false;
+            return false;
+        }
     }
 
     private async Task StopAsync()

--- a/ToDoTimeManager.WebUI.Services/Services/Implementations/SignalRService.cs
+++ b/ToDoTimeManager.WebUI.Services/Services/Implementations/SignalRService.cs
@@ -51,11 +51,16 @@ public class SignalRService : ISignalRService
         try
         {
             await _connection.StartAsync(ct);
+
+            if (_connection.State != HubConnectionState.Connected)
+                throw new InvalidOperationException($"SignalR connection did not reach the connected state. Current state: {_connection.State}.");
+
             _logger.LogInformation("SignalR connected.");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to start SignalR connection.");
+            throw;
         }
     }
 

--- a/ToDoTimeManager.WebUI.Services/Services/Implementations/SignalRService.cs
+++ b/ToDoTimeManager.WebUI.Services/Services/Implementations/SignalRService.cs
@@ -1,0 +1,89 @@
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using ToDoTimeManager.WebUI.Services.Helpers.CircuitServicesAccesor;
+using ToDoTimeManager.WebUI.Services.Services.Interfaces;
+using ToDoTimeManager.WebUI.Utils.PotectedLocalStorageHelpers;
+
+namespace ToDoTimeManager.WebUI.Services.Services.Implementations;
+
+public class SignalRService : ISignalRService
+{
+    private readonly CircuitServicesAccesor _accessor;
+    private readonly ILogger<SignalRService> _logger;
+    private readonly HubConnection _connection;
+
+    public HubConnectionState State => _connection.State;
+
+    public SignalRService(
+        CircuitServicesAccesor accessor,
+        IConfiguration configuration,
+        ILogger<SignalRService> logger)
+    {
+        _accessor = accessor;
+        _logger   = logger;
+
+        var apiBase = configuration["BaseApiUrlAddress"]?.TrimEnd('/') ?? "https://webapi";
+        var hubUrl  = $"{apiBase}/hubs/communication";
+
+        _connection = new HubConnectionBuilder()
+            .WithUrl(hubUrl, options => { options.AccessTokenProvider = GetAccessTokenAsync; })
+            .WithAutomaticReconnect([
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(30)
+            ])
+            .Build();
+
+        _connection.Closed      += ex => { if (ex != null) _logger.LogWarning(ex, "SignalR closed with error."); return Task.CompletedTask; };
+        _connection.Reconnecting += ex => { _logger.LogInformation("SignalR reconnecting: {Reason}", ex?.Message); return Task.CompletedTask; };
+        _connection.Reconnected  += id => { _logger.LogInformation("SignalR reconnected. ConnectionId={Id}", id); return Task.CompletedTask; };
+    }
+
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        if (_connection.State is HubConnectionState.Connected or HubConnectionState.Connecting)
+            return;
+
+        try
+        {
+            await _connection.StartAsync(ct);
+            _logger.LogInformation("SignalR connected.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start SignalR connection.");
+        }
+    }
+
+    public async Task StopAsync(CancellationToken ct = default)
+    {
+        try { await _connection.StopAsync(ct); }
+        catch (Exception ex) { _logger.LogWarning(ex, "Error stopping SignalR connection."); }
+    }
+
+    public IDisposable On<T>(string method, Action<T> handler)
+        => _connection.On(method, handler);
+
+    private async Task<string?> GetAccessTokenAsync()
+    {
+        try
+        {
+            var storage = _accessor.Service?.GetService<ProtectedLocalStorage>();
+            if (storage == null) return null;
+            var tokens = await storage.GetTokenAsync();
+            return tokens?.AccessToken;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to retrieve access token for SignalR.");
+            return null;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+        => await _connection.DisposeAsync();
+}

--- a/ToDoTimeManager.WebUI.Services/Services/Interfaces/ISignalRService.cs
+++ b/ToDoTimeManager.WebUI.Services/Services/Interfaces/ISignalRService.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace ToDoTimeManager.WebUI.Services.Services.Interfaces;
+
+public interface ISignalRService : IAsyncDisposable
+{
+    HubConnectionState State { get; }
+    Task StartAsync(CancellationToken ct = default);
+    Task StopAsync(CancellationToken ct = default);
+    IDisposable On<T>(string method, Action<T> handler);
+}

--- a/ToDoTimeManager.WebUI.Services/ToDoTimeManager.WebUI.Services.csproj
+++ b/ToDoTimeManager.WebUI.Services/ToDoTimeManager.WebUI.Services.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ToDoTimeManager.Shared\ToDoTimeManager.Shared.csproj" />
     <ProjectReference Include="..\ToDoTimeManager.WebUI.Utils\ToDoTimeManager.WebUI.Utils.csproj" />
     <ProjectReference Include="..\ToDoTimeManager.WebUI.Models\ToDoTimeManager.WebUI.Models.csproj" />

--- a/ToDoTimeManager.WebUI/Program.cs
+++ b/ToDoTimeManager.WebUI/Program.cs
@@ -44,6 +44,7 @@ public class Program
         builder.Services.AddScoped<TeamsService>();
         builder.Services.AddScoped<ProjectsService>();
 
+        builder.Services.AddScoped<ISignalRService, SignalRService>();
         builder.Services.AddScoped<AuthenticationStateProvider, CustomAuthStateProvider>();
 
         builder.Services.AddHttpClient("TodoTimeManager", client =>


### PR DESCRIPTION
## Summary

- **`CommunicationHub`** — авторизований SignalR хаб з автоматичним роутингом по групах (`user-{id}`, `team-{id}`, `project-{id}`, `role-managers`). Використовує ID-only методи замість повних сутностей.
- **`IHubNotifier` / `HubNotifier`** — friendly API для надсилання повідомлень: `NotifyUserAsync`, `NotifyTeamAsync`, `NotifyProjectAsync`, `NotifyManagersAsync`.
- **`ISignalRService` / `SignalRService`** — клієнтський сервіс на WebUI з `On<T>` для підписки компонентів на вхідні повідомлення.
- **`SignalRConnector.razor`** — lifecycle компонент в `MainLayout`, підключає/відключає хаб при зміні стану авторизації.
- **ID-only stored procedures** — `sp_Teams_GetIdsByUserId`, `sp_Projects_GetIdsByUserId` для ефективного роутингу без завантаження повних сутностей.
- **CLAUDE.md** — правила 13 (ID-only queries) та 14 (code-behind preference).

## Test plan

- [ ] Авторизуватись → в логах WebUI побачити `SignalR connected.`
- [ ] Без токену (не авторизовано) → WS upgrade повертає 401
- [ ] Logout → `StopAsync` викликається, з'єднання закривається
- [ ] Reconnect: зупинити WebApi → перезапустити → `SignalR reconnecting → reconnected`
- [ ] Inject `IHubNotifier` у тестовий контролер та надіслати повідомлення — отримати його у компоненті через `SignalRService.On<T>`

https://claude.ai/code/session_01VzWhMf7WWVrfQsBHKayNN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzWhMf7WWVrfQsBHKayNN9)_